### PR TITLE
Resetting CPU start time on reoptimize of IpoptApplication

### DIFF
--- a/Ipopt/src/Algorithm/IpIpoptData.hpp
+++ b/Ipopt/src/Algorithm/IpIpoptData.hpp
@@ -484,6 +484,12 @@ namespace Ipopt
       return timing_statistics_;
     }
 
+    /** Resetting CPU Start Time */
+    void ResetCpuStartTime()
+    {
+      cpu_time_start_ = CpuTime();
+    }
+
     /** Check if additional data has been set */
     bool HaveAddData()
     {

--- a/Ipopt/src/Interfaces/IpIpoptApplication.cpp
+++ b/Ipopt/src/Interfaces/IpIpoptApplication.cpp
@@ -850,6 +850,9 @@ namespace Ipopt
     ip_data_->TimingStats().ResetTimes();
     p2ip_nlp->ResetTimes();
 
+    // Reset Cpu start time (so doesn't carry over, on ReOptimize)
+    ip_data_->ResetCpuStartTime();
+
     ApplicationReturnStatus retValue = Internal_Error;
     SolverReturn status = INTERNAL_ERROR;
     /** Flag indicating if the NLP:FinalizeSolution method should not


### PR DESCRIPTION
I noticed some unexpected behaviour when trying to utilise a max_cpu_time while using the ReOptimizeNLP feature of IpotApplication.  The time seems to be adding up cumulatively on repeated optimizations, until it reaches a point where Maximum_CpuTime_Exceeded returns immediately on an attempted resolve.

I tracked this down to the IpoptData cpu_time_start_ member variable not getting reset when ReOptimizeNLP is called.

I've tested the changes at it now works as expected (or at least how I expected it to work).  Let me know if you need additional information or would rather another approach to solving this.