### PR TITLE
Initialize DMUMPS_STRUC_C to zero before use

### DIFF
--- a/Ipopt/src/Algorithm/LinearSolvers/IpMumpsSolverInterface.cpp
+++ b/Ipopt/src/Algorithm/LinearSolvers/IpMumpsSolverInterface.cpp
@@ -46,6 +46,8 @@
 # endif
 #endif
 
+#include <cstring>
+
 namespace Ipopt
 {
 #if COIN_IPOPT_VERBOSITY > 0
@@ -62,6 +64,7 @@ namespace Ipopt
                    dbg_verbosity);
     //initialize mumps
     DMUMPS_STRUC_C* mumps_ = new DMUMPS_STRUC_C;
+    std::memset(mumps_, 0, sizeof(DMUMPS_STRUC_C));
 #ifndef MUMPS_MPI_H
 #if defined(HAVE_MPI_INITIALIZED)
     int mpi_initialized;


### PR DESCRIPTION
This resolves the use of not initialized memory when IPOPT is compiled with MUMPS 5.1.0 or greater. 

Even if IPOPT does not officially support MUMPS 5, Debian/Ubuntu and homebrew packages have switched to use Mumps 5.1.2 . This creates a problem because, while Mumps interface of IPOPT compiles fine, MUMPS introduced in version 5.1.0 some new parameters in its interface: 
> * New feature: selective 64-bit integers (introduced only where needed)
>  to process matrices with more than 2^{31}-1 entries.
 >  mixed 32/64 bit integers for API: NNZ/NNZ_loc 64-bit
 >  (NZ/NZ_LOC kept temporarily for backward compatibility)
 > both 32 or 64 bit integer versions of external orderings 
 >   (Metis/ParMetis, SCOTCH/pt-SCOTCH, PORD), can be used
 >   Error -51 when a 32-bit external ordering is invoked on 
 >   a graph larger than  2^{31}-1

For example, the 64-bit `nnz` attribute of the  `DMUMPS_STRUC_C` is now used instead of the `nz` parameter if the [nnz parameter is positive nonzero](https://salsa.debian.org/science-team/mumps/commit/cb40d420da8a45fccf422a16502d8ac75d6279d2#b3ca548083b9cd8c7dbe469c41cc60457d94bb46_0_824). However, IPOPT does not set this new parameter, so its value is actually undefined and depends on the state of the memory. While improbable, it is possible for this value to have an arbitrary positive nonzero value, and this would cause a crash in the library. 
If we initialize the `DMUMPS_STRUC_C`, we are at least sure that any behavior of the library is always completely reproducible. 

See https://github.com/robotology/idyntree/issues/456 for more details.

Related issue: I am not sure, but it is possible that the person that reported problems with predictability with IPOPT using MUMPS in https://projects.coin-or.org/Ipopt/ticket/296 could be affected by an  issue similar to this one. 