### PR TITLE
ensure journalist used for debugging is not freed with ipopt application

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -5,6 +5,9 @@ commit history.
 2020-xx-yy: 3.13.3
         - Members of AmplTNLP class are now protected instead of private.
         - Updated Eclipse Public License from 1.0 to 2.0.
+        - Fixed dangling pointer problems with Journalist used for debugging
+          (--with-ipopt-verbosity > 0) when more than one IpoptApplication
+          is used. [#393, thanks to Brad Bell]
 
 2020-04-30: 3.13.2
         - The C-preprocessor defines COIN_IPOPT_CHECKLEVEL,

--- a/src/Common/IpDebug.hpp
+++ b/src/Common/IpDebug.hpp
@@ -97,16 +97,18 @@ public:
       ...
    );
 
+private:
+   friend class IpoptApplication;
    /* Method for initialization of the static GLOBAL journalist,
     * through with all debug printout is to be written.
     *
     * This needs to be set before any debug printout can be done.
+    * It is expected that this is only called by the IpoptApplication constructor.
     */
    static void SetJournalist(
       Journalist* jrnl
    );
 
-private:
    /**@name Default Compiler Generated Methods
     * (Hidden to avoid implicit creation/calling).
     *


### PR DESCRIPTION
- this introduces a memory leak
- pass debug-Journal from debug-Journalist to current Journalist in IpoptApplication::Initialize to avoid writing into a still open debug.out

Closes #393.