### PR TITLE
Fix constraint name mapping for inequalities.

### DIFF
--- a/src/Interfaces/IpTNLPAdapter.cpp
+++ b/src/Interfaces/IpTNLPAdapter.cpp
@@ -928,19 +928,19 @@ bool TNLPAdapter::GetSpaces(
 
             string_md.clear();
             string_md.resize(n_d_l);
-            pos_idx = P_d_l_space->ExpandedPosIndices();
+            const Index* d_pos_idx = P_d_l_space->ExpandedPosIndices();
             for( Index i = 0; i < n_d_l; i++ )
             {
-               string_md[i] = iter->second[pos_idx[i]];
+               string_md[i] = iter->second[pos_idx[d_pos_idx[i]]];
             }
             dv_d_l_space->SetStringMetaData(iter->first, string_md);
 
             string_md.clear();
             string_md.resize(n_d_u);
-            pos_idx = P_d_u_space->ExpandedPosIndices();
+            d_pos_idx = P_d_u_space->ExpandedPosIndices();
             for( Index i = 0; i < n_d_u; i++ )
             {
-               string_md[i] = iter->second[pos_idx[i]];
+               string_md[i] = iter->second[pos_idx[d_pos_idx[i]]];
             }
             dv_d_u_space->SetStringMetaData(iter->first, string_md);
          }


### PR DESCRIPTION
Here, I refer to a set of constraints by it's cardinality. In lines 562 to 607, 4 maps are created:
- `c_map`: from `nc` to `n_full_g_`
- `d_map`: from `n_d` to `n_full_g_`
- `d_l_map`: from `n_d_l` to `n_d`
- `d_u_map`: from `n_d_u` to `n_d`

So to retrieve the name of some inequality with only lower bounds, we need to lookup it's index in `n_d` using `d_l_map` and then lookup the found index in `n_full_g_` using `d_map`, since no map from `n_d_l` to `n_full_g` was created.