### PR TITLE
Fix configure script

### DIFF
--- a/configure
+++ b/configure
@@ -22868,7 +22868,7 @@ fi
     if test -n "$with_lapack_lflags" ; then
 
   ac_save_LIBS="$LIBS"
-  LIBS="$with_lapack_lflags $LIBS"
+  LIBS="$(echo $(echo $with_lapack_lflags $LIBS) | xargs)"
 
 
   dsyev_namemangling=unknown


### PR DESCRIPTION
I am writing an IPOPT wrapper that uses CMake to download IPOPT dependencies. In CMake I pass LAPACK link flags as
`--with-lapack-lflags="-L${CMAKE_CURRENT_BINARY_DIR}/3rd_party/src/LAPACK/build/lib -llapack -lblas -lm -lgfortran"`. Unfortunately the `configure` script then defines `LIBS` as `"-L/home/felix/git/scientific-software/IPOPT_CMake/build/3rd_party/src/LAPACK/build/lib -llapack -lblas -lm -lgfortran"
`, incorrectly including the quotes. By defining `LIBS` as `LIBS="$(echo $(echo $with_lapack_lflags $LIBS) | xargs)"` instead of `LIBS="$with_lapack_lflags $LIBS"`, this problem can be fixed.