### PR TITLE
fix mapping of meta data for variable bounds

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,11 @@ More detailed information about incremental changes can be found in the
 
 ## 3.14
 
+### 3.14.9 (2022-07-21)
+
+- Fixed mapping of meta data for variable bounds, e.g., variable names,
+  from TNLP to Ipopts internal NLP [#590].
+
 ### 3.14.8 (2022-07-13)
 
 - Added options ma27_print_level, ma57_print_level, and mumps_print_level

--- a/src/Interfaces/IpTNLPAdapter.cpp
+++ b/src/Interfaces/IpTNLPAdapter.cpp
@@ -751,19 +751,33 @@ bool TNLPAdapter::GetSpaces(
 
             string_md.clear();
             string_md.resize(n_x_l);
-            pos_idx = P_x_x_L_space_->ExpandedPosIndices();
+            const Index* pos_idxL = P_x_x_L_space_->ExpandedPosIndices();
             for( Index i = 0; i < n_x_l; i++ )
             {
-               string_md[i] = iter->second[pos_idx[i]];
+               if( pos_idx != NULL )
+               {
+                  string_md[i] = iter->second[pos_idx[pos_idxL[i]]];
+               }
+               else
+               {
+                  string_md[i] = iter->second[pos_idxL[i]];
+               }
             }
             dv_x_l_space->SetStringMetaData(iter->first, string_md);
 
             string_md.clear();
             string_md.resize(n_x_u);
-            pos_idx = P_x_x_U_space_->ExpandedPosIndices();
+            const Index* pos_idxU = P_x_x_U_space_->ExpandedPosIndices();
             for( Index i = 0; i < n_x_u; i++ )
             {
-               string_md[i] = iter->second[pos_idx[i]];
+               if( pos_idx != NULL )
+               {
+                  string_md[i] = iter->second[pos_idx[pos_idxU[i]]];
+               }
+               else
+               {
+                  string_md[i] = iter->second[pos_idxU[i]];
+               }
             }
             dv_x_u_space->SetStringMetaData(iter->first, string_md);
          }
@@ -794,19 +808,33 @@ bool TNLPAdapter::GetSpaces(
 
             integer_md.clear();
             integer_md.resize(n_x_l);
-            pos_idx = P_x_x_L_space_->ExpandedPosIndices();
+            const Index* pos_idxL = P_x_x_L_space_->ExpandedPosIndices();
             for( Index i = 0; i < n_x_l; i++ )
             {
-               integer_md[i] = iter->second[pos_idx[i]];
+               if( pos_idx != NULL )
+               {
+                  integer_md[i] = iter->second[pos_idx[pos_idxL[i]]];
+               }
+               else
+               {
+                  integer_md[i] = iter->second[pos_idxL[i]];
+               }
             }
             dv_x_l_space->SetIntegerMetaData(iter->first, integer_md);
 
             integer_md.clear();
             integer_md.resize(n_x_u);
-            pos_idx = P_x_x_U_space_->ExpandedPosIndices();
+            const Index* pos_idxU = P_x_x_U_space_->ExpandedPosIndices();
             for( Index i = 0; i < n_x_u; i++ )
             {
-               integer_md[i] = iter->second[pos_idx[i]];
+               if( pos_idx != NULL )
+               {
+                  integer_md[i] = iter->second[pos_idx[pos_idxU[i]]];
+               }
+               else
+               {
+                  integer_md[i] = iter->second[pos_idxU[i]];
+               }
             }
             dv_x_u_space->SetIntegerMetaData(iter->first, integer_md);
          }
@@ -837,19 +865,33 @@ bool TNLPAdapter::GetSpaces(
 
             numeric_md.clear();
             numeric_md.resize(n_x_l);
-            pos_idx = P_x_x_L_space_->ExpandedPosIndices();
+            const Index* pos_idxL = P_x_x_L_space_->ExpandedPosIndices();
             for( Index i = 0; i < n_x_l; i++ )
             {
-               numeric_md[i] = iter->second[pos_idx[i]];
+               if( pos_idx != NULL )
+               {
+                  numeric_md[i] = iter->second[pos_idx[pos_idxL[i]]];
+               }
+               else
+               {
+                  numeric_md[i] = iter->second[pos_idxL[i]];
+               }
             }
             dv_x_l_space->SetNumericMetaData(iter->first, numeric_md);
 
             numeric_md.clear();
             numeric_md.resize(n_x_u);
-            pos_idx = P_x_x_U_space_->ExpandedPosIndices();
+            const Index* pos_idxU = P_x_x_U_space_->ExpandedPosIndices();
             for( Index i = 0; i < n_x_u; i++ )
             {
-               numeric_md[i] = iter->second[pos_idx[i]];
+               if( pos_idx != NULL )
+               {
+                  numeric_md[i] = iter->second[pos_idx[pos_idxU[i]]];
+               }
+               else
+               {
+                  numeric_md[i] = iter->second[pos_idxU[i]];
+               }
             }
             dv_x_u_space->SetNumericMetaData(iter->first, numeric_md);
          }


### PR DESCRIPTION
Mapping from full x to x without fixed vars was not taken into account.

@danieloliveira56 I think this should fix the issue with the variable names for variable bounds that you reported to GAMS support.
It looks to me like when going from full x to the reduced x (fixed variables removed), things were ok and that's why we got
```
initial x unscaled[    1]{y}= 0.0000000000000000e+00
initial x unscaled[    2]{z}= 0.0000000000000000e+00
initial x unscaled[    3]{w}= 0.0000000000000000e+00
```
But for the lower variable bounds (x_L), both the mapping from full x to the reduced x and then from the reduced x to the variables with lower bound needs to be taken into account. But only the latter was used in the code. (same for x_U)

So here I change it to use `pos_idx` (full x -> reduced x) and pos_idxL (reduced x -> x_L).
I now get
```
DenseVector "original x_L unscaled" with 3 elements:
original x_L unscaled[    1]{y}=-2.0000000000000000e+00
original x_L unscaled[    2]{z}=-3.0000000000000000e+00
original x_L unscaled[    3]{w}=-4.0000000000000000e+00
DenseVector "original x_U unscaled" with 3 elements:
original x_U unscaled[    1]{y}= 2.0000000000000000e+00
original x_U unscaled[    2]{z}= 3.0000000000000000e+00
original x_U unscaled[    3]{w}= 4.0000000000000000e+00
```

As you are an expert on this kind of Ipopt code (#570), I thought I may ask you to have another look. :)