### PR TITLE
Add missing headers to install.

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -59,11 +59,15 @@ includeipopt_HEADERS = \
   Algorithm/IpNLPScaling.hpp \
   Algorithm/IpPDSystemSolver.hpp \
   Algorithm/IpSearchDirCalculator.hpp \
-  Algorithm/IpStdAugSystemSolver.cpp \
+  Algorithm/IpStdAugSystemSolver.hpp \
   Algorithm/IpTimingStatistics.hpp \
+  Algorithm/LinearSolvers/IpLinearSolvers.h \
+  Algorithm/LinearSolvers/IpSlackBasedTSymScalingMethod.hpp \
   Algorithm/LinearSolvers/IpSparseSymLinearSolverInterface.hpp \
   Algorithm/LinearSolvers/IpSymLinearSolver.hpp \
-  Algorithm/LinearSolvers/IpLinearSolvers.h \
+  Algorithm/LinearSolvers/IpTripletToCSRConverter.hpp \
+  Algorithm/LinearSolvers/IpTSymLinearSolver.hpp \
+  Algorithm/LinearSolvers/IpTSymScalingMethod.hpp \
   Interfaces/IpAlgTypes.hpp \
   Interfaces/IpIpoptApplication.hpp \
   Interfaces/IpNLP.hpp \

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -756,11 +756,15 @@ includeipopt_HEADERS = \
   Algorithm/IpNLPScaling.hpp \
   Algorithm/IpPDSystemSolver.hpp \
   Algorithm/IpSearchDirCalculator.hpp \
-  Algorithm/IpStdAugSystemSolver.cpp \
+  Algorithm/IpStdAugSystemSolver.hpp \
   Algorithm/IpTimingStatistics.hpp \
+  Algorithm/LinearSolvers/IpLinearSolvers.h \
+  Algorithm/LinearSolvers/IpSlackBasedTSymScalingMethod.hpp \
   Algorithm/LinearSolvers/IpSparseSymLinearSolverInterface.hpp \
   Algorithm/LinearSolvers/IpSymLinearSolver.hpp \
-  Algorithm/LinearSolvers/IpLinearSolvers.h \
+  Algorithm/LinearSolvers/IpTripletToCSRConverter.hpp \
+  Algorithm/LinearSolvers/IpTSymLinearSolver.hpp \
+  Algorithm/LinearSolvers/IpTSymScalingMethod.hpp \
   Interfaces/IpAlgTypes.hpp \
   Interfaces/IpIpoptApplication.hpp \
   Interfaces/IpNLP.hpp \


### PR DESCRIPTION
- These headers are required to use custom linear solvers on the user side.
- Fixes #618, #637, #641.