### PR TITLE
Update HSL_MA97 headers for new version

### DIFF
--- a/src/Algorithm/LinearSolvers/hsl_ma97d.h
+++ b/src/Algorithm/LinearSolvers/hsl_ma97d.h
@@ -5,7 +5,7 @@
  *
  * Written by: Jonathan Hogg
  *
- * Version 2.6.0
+ * Version 2.8.0
  *
  * THIS FILE ONLY may be redistributed under the below modified BSD licence.
  * All other files distributed as part of the HSL_MA97 package
@@ -96,7 +96,7 @@ struct ma97_control_d {
     int ispare[5]; ma97realtype_d_ rspare[10];
 };
 
-struct ma97_info {
+struct ma97_info_d {
     int flag;                 /* <0 on error */
     int flag68;
     int flag77;
@@ -105,7 +105,7 @@ struct ma97_info {
     int matrix_outrange;      /* number of out of range entries in A */
     int matrix_missing_diag;  /* number of zero diagonal entries in A */
     int maxdepth;             /* height of assembly tree */
-    int maxfront;             /* maximum dimension of frontal matrix */
+    int maxfront;             /* maximum no. rows in a supernode */
     int num_delay;            /* number of times a pivot was delayed */
     long num_factor;          /* number of entries in L */
     long num_flops;           /* number of floating point operations */
@@ -114,9 +114,10 @@ struct ma97_info {
     int num_two;              /* number of 2x2 pivots */
     int ordering;             /* ordering used (as per control.ordering) */
     int stat;                 /* error code from failed memory allocation */
+    int maxsupernode;         /* maximum no. columns in a supernode */
 
     /* Reserve space for future interface changes */
-    int ispare[5]; ma97realtype_d_ rspare[10];         
+    int ispare[4]; ma97realtype_d_ rspare[10];
 };
 
 /* Set default values of control */

--- a/src/Algorithm/LinearSolvers/hsl_ma97s.h
+++ b/src/Algorithm/LinearSolvers/hsl_ma97s.h
@@ -5,7 +5,7 @@
  *
  * Written by: Jonathan Hogg
  *
- * Version 2.6.0
+ * Version 2.8.0
  *
  * THIS FILE ONLY may be redistributed under the below modified BSD licence.
  * All other files distributed as part of the HSL_MA97 package
@@ -96,7 +96,7 @@ struct ma97_control_s {
     int ispare[5]; ma97realtype_s_ rspare[10];
 };
 
-struct ma97_info {
+struct ma97_info_s {
     int flag;                 /* <0 on error */
     int flag68;
     int flag77;
@@ -105,7 +105,7 @@ struct ma97_info {
     int matrix_outrange;      /* number of out of range entries in A */
     int matrix_missing_diag;  /* number of zero diagonal entries in A */
     int maxdepth;             /* height of assembly tree */
-    int maxfront;             /* maximum dimension of frontal matrix */
+    int maxfront;             /* maximum no. rows in a supernode */
     int num_delay;            /* number of times a pivot was delayed */
     long num_factor;          /* number of entries in L */
     long num_flops;           /* number of floating point operations */
@@ -114,9 +114,10 @@ struct ma97_info {
     int num_two;              /* number of 2x2 pivots */
     int ordering;             /* ordering used (as per control.ordering) */
     int stat;                 /* error code from failed memory allocation */
+    int maxsupernode;         /* maximum no. columns in a supernode */
 
     /* Reserve space for future interface changes */
-    int ispare[5]; ma97realtype_s_ rspare[10];         
+    int ispare[4]; ma97realtype_s_ rspare[10];
 };
 
 /* Set default values of control */


### PR DESCRIPTION
Hi @svigerske 

We're in the process of updating HSL_MA97 to v2.8.0 and in particular we have found an error in the reporting of the maximum front size statistic. This is being corrected to report the maximum number of rows in a supernode and the previously reported statistic is being reported as the maximum supernode size.

This has necessitated adding a new `maxsupernode` member to the `ma97_info` structs, using up one of the reserved integer spaces in the struct. As the info struct size remains the same I believe this change should be full backward compatible (earlier versions of HSL_MA97 will simply not have this entry set).

However, if you do think that this will be a breaking change, we are happy to drop it from the C interface.