### PR TITLE
Update HSL_MC68 header

### DIFF
--- a/src/Algorithm/LinearSolvers/hsl_mc68i.h
+++ b/src/Algorithm/LinearSolvers/hsl_mc68i.h
@@ -53,7 +53,7 @@ struct mc68_control_i {
    int f_array_out;     /* 0 for C array indexing, 1 for Fortran indexing
                          * NOTE: 2x2 pivot information discarded if C indexing
                          * is used for output! */
-   long min_l_workspace; /* Initial size of workspace, as argument in Fortran */
+   int min_l_workspace; /* Initial size of workspace, as argument in Fortran */
    /* Options from Fortran version */
    int lp;              /* stream number for error messages */
    int wp;              /* stream number for warning messages */


### PR DESCRIPTION
We have found a minor bug in the HSL_MC68 C header that we have been shipping to date, that is the `control.min_l_workspace` parameter had the wrong type in the C header. This has now been corrected so that it has integer type as is the case in the rest of the C interface and the Fortran code. Please see the HSL_MC68 changelog:
https://www.hsl.rl.ac.uk/catalogue/hsl_mc68.html

I can only assume that this optional parameter was not used as we would expect the mismatch in structs on the C and Fortran side to cause mangling of members in the C control struct (this is a major weakness of Fortran ISO C interfacing).