### PR TITLE
Use LoadLibraryExA for more robust library loading

### DIFF
--- a/src/Common/IpLibraryLoader.cpp
+++ b/src/Common/IpLibraryLoader.cpp
@@ -51,6 +51,12 @@ void LibraryLoader::loadLibrary()
 
 #ifdef HAVE_WINDOWS_H
    libhandle = (void*)LoadLibrary(libname.c_str());
+
+   if( libhandle == NULL )
+   {
+      libhandle = (void*)LoadLibraryExA(libname.c_str(), NULL, LOAD_LIBRARY_SEARCH_DEFAULT_DIRS | LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR);
+   }
+   
    if( libhandle == NULL )
    {
       std::stringstream s;

--- a/src/Common/IpLibraryLoader.cpp
+++ b/src/Common/IpLibraryLoader.cpp
@@ -50,13 +50,8 @@ void LibraryLoader::loadLibrary()
    }
 
 #ifdef HAVE_WINDOWS_H
-   libhandle = (void*)LoadLibrary(libname.c_str());
+   libhandle = (void*)LoadLibraryExA(libname.c_str(), NULL, LOAD_LIBRARY_SEARCH_DEFAULT_DIRS | LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR);
 
-   if( libhandle == NULL )
-   {
-      libhandle = (void*)LoadLibraryExA(libname.c_str(), NULL, LOAD_LIBRARY_SEARCH_DEFAULT_DIRS | LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR);
-   }
-   
    if( libhandle == NULL )
    {
       std::stringstream s;


### PR DESCRIPTION
The Windows DLL search path is cumbersome : https://learn.microsoft.com/en-us/windows/win32/api/libloaderapi/nf-libloaderapi-loadlibraryexa
For example, if the `libhsl.dll` in located in `D:\hsl` directory:
```
D:\hsl
| - libhsl.dll
| - libmetis.dll
| - ...
```
The `libhsl.dll` depends on `libmetis.dll`, but `LoadLibrary("D:\\hsl\\libhsl.dll")` cannot load `libmetis.dll` in the same directory.
By using `LoadLibraryExA` function, setting `LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR` flag can add the directory that contains the DLL temporarily to the beginning of the list of directories that are searched for the DLL's dependencies. In this way, `libmetis.dll` can be loaded successfully.