### PR TITLE
Fix include guard in IpGenAugSystemSolver.hpp

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,6 +9,7 @@ More detailed information about incremental changes can be found in the
 
 ### 3.14.15 (2024-xx-yy)
 
+- Fixed include guard of IpGenAugSystemSolver.hpp [#756, by Christopher Wellons].
 - Improved finding dependencies of linear solver libraries loaded at runtime on Windows
   [#755, by Yue Yang].
 

--- a/src/Algorithm/IpGenAugSystemSolver.hpp
+++ b/src/Algorithm/IpGenAugSystemSolver.hpp
@@ -4,8 +4,8 @@
 //
 // Authors:  Andreas Waechter     IBM    2007-03-01
 
-#ifndef __IP_STDAUGSYSTEMSOLVER_HPP__
-#define __IP_STDAUGSYSTEMSOLVER_HPP__
+#ifndef __IP_GENAUGSYSTEMSOLVER_HPP__
+#define __IP_GENAUGSYSTEMSOLVER_HPP__
 
 #include "IpAugSystemSolver.hpp"
 #include "IpGenKKTSolverInterface.hpp"


### PR DESCRIPTION
Appears to be a copy-paste error from IpStdAugSystemSolver.hpp.