### PR TITLE
Conventional naming `main()` arguments

### DIFF
--- a/contrib/sIPOPT/AmplSolver/ampl_sipopt.cpp
+++ b/contrib/sIPOPT/AmplSolver/ampl_sipopt.cpp
@@ -12,8 +12,8 @@
 #include "SensRegOp.hpp"
 
 int main(
-   int    /*argv*/,
-   char** argc
+   int    /*argc*/,
+   char** /*argv*/
 )
 {
    using namespace Ipopt;

--- a/contrib/sIPOPT/AmplSolver/ampl_sipopt.cpp
+++ b/contrib/sIPOPT/AmplSolver/ampl_sipopt.cpp
@@ -13,7 +13,7 @@
 
 int main(
    int    /*argc*/,
-   char** /*argv*/
+   char** argv
 )
 {
    using namespace Ipopt;
@@ -123,7 +123,7 @@ int main(
                                     "Number of sensitivity steps");
 
    // create AmplSensTNLP from argc.
-   SmartPtr<TNLP> sens_tnlp = new SensAmplTNLP(ConstPtr(app_ipopt->Jnlst()), app_ipopt->RegOptions(), app_ipopt->Options(), argc, suffix_handler,
+   SmartPtr<TNLP> sens_tnlp = new SensAmplTNLP(ConstPtr(app_ipopt->Jnlst()), app_ipopt->RegOptions(), app_ipopt->Options(), argv, suffix_handler,
       false, ampl_options_list);
 
    app_sens->Initialize();

--- a/contrib/sIPOPT/examples/parametric_cpp/parametric_driver.cpp
+++ b/contrib/sIPOPT/examples/parametric_cpp/parametric_driver.cpp
@@ -12,8 +12,8 @@
 #include "SensRegOp.hpp"
 
 int main(
-   int    /*argv*/,
-   char** /*argc*/
+   int    /*argc*/,
+   char** /*argv*/
 )
 {
    using namespace Ipopt;

--- a/contrib/sIPOPT/examples/parametric_dsdp_cpp/parametric_dsdp_driver.cpp
+++ b/contrib/sIPOPT/examples/parametric_dsdp_cpp/parametric_dsdp_driver.cpp
@@ -12,8 +12,8 @@
 #include "SensRegOp.hpp"
 
 int main(
-   int    /*argv*/,
-   char** /*argc*/
+   int    /*argc*/,
+   char** /*argv*/
 )
 {
    using namespace Ipopt;

--- a/contrib/sIPOPT/examples/redhess_cpp/redhess_cpp.cpp
+++ b/contrib/sIPOPT/examples/redhess_cpp/redhess_cpp.cpp
@@ -12,8 +12,8 @@
 #include "SensRegOp.hpp"
 
 int main(
-   int    /*argv*/,
-   char** /*argc*/
+   int    /*argc*/,
+   char** /*argv*/
 )
 {
 

--- a/examples/ScalableProblems/solve_problem.cpp
+++ b/examples/ScalableProblems/solve_problem.cpp
@@ -97,11 +97,11 @@ static void print_problems()
 }
 
 int main(
-   int   argv,
-   char* argc[]
+   int   argc,
+   char* argv[]
 )
 {
-   if( argv == 2 && !strcmp(argc[1], "list") )
+   if( argc == 2 && !strcmp(argv[1], "list") )
    {
       print_problems();
       return 0;
@@ -109,18 +109,18 @@ int main(
 
 #ifdef TIME_LIMIT
    int runtime;
-   if( argv == 4 )
+   if( argc == 4 )
    {
-      runtime = atoi(argc[3]);
+      runtime = atoi(argv[3]);
    }
    else
 #endif
-      if( argv != 3 && argv != 1 )
+      if( argc != 3 && argc != 1 )
       {
-         printf("Usage: %s (this will ask for problem name)\n", argc[0]);
-         printf("       %s ProblemName N\n", argc[0]);
+         printf("Usage: %s (this will ask for problem name)\n", argv[0]);
+         printf("       %s ProblemName N\n", argv[0]);
          printf("          where N is a positive parameter determining problem size\n");
-         printf("       %s list\n", argc[0]);
+         printf("       %s list\n", argv[0]);
          printf("          to list all registered problems.\n");
          return -1;
       }
@@ -128,18 +128,18 @@ int main(
    SmartPtr<RegisteredTNLP> tnlp;
    Index N;
 
-   if( argv != 1 )
+   if( argc != 1 )
    {
       // Create an instance of your nlp...
-      tnlp = RegisteredTNLPs::GetTNLP(argc[1]);
+      tnlp = RegisteredTNLPs::GetTNLP(argv[1]);
       if( !IsValid(tnlp) )
       {
-         printf("Problem with name \"%s\" not known.\n", argc[1]);
+         printf("Problem with name \"%s\" not known.\n", argv[1]);
          print_problems();
          return -2;
       }
 
-      N = atoi(argc[2]);
+      N = atoi(argv[2]);
    }
    else
    {

--- a/examples/hs071_cpp/hs071_main.cpp
+++ b/examples/hs071_cpp/hs071_main.cpp
@@ -13,8 +13,8 @@
 using namespace Ipopt;
 
 int main(
-   int    /*argv*/,
-   char** /*argc*/
+   int    /*argc*/,
+   char** /*argv*/
 )
 {
    // Create a new instance of your nlp

--- a/tutorial/CodingExercise/Cpp/1-skeleton/TutorialCpp_main.cpp
+++ b/tutorial/CodingExercise/Cpp/1-skeleton/TutorialCpp_main.cpp
@@ -28,8 +28,8 @@
 using namespace Ipopt;
 
 int main(
-   int   argv,
-   char* argc[]
+   int   /*argc*/,
+   char* /*argv[]*/
 )
 {
    // Set the data:

--- a/tutorial/CodingExercise/Cpp/2-mistake/TutorialCpp_main.cpp
+++ b/tutorial/CodingExercise/Cpp/2-mistake/TutorialCpp_main.cpp
@@ -29,8 +29,8 @@
 using namespace Ipopt;
 
 int main(
-   int argv,
-   char* argc[]
+   int    /*argc*/,
+   char** /*argc*/
 )
 {
    // Set the data:

--- a/tutorial/CodingExercise/Cpp/3-solution/TutorialCpp_main.cpp
+++ b/tutorial/CodingExercise/Cpp/3-solution/TutorialCpp_main.cpp
@@ -31,8 +31,8 @@
 using namespace Ipopt;
 
 int main(
-   int argv,
-   char* argc[]
+   int    /*argc*/,
+   char** /*argv*/
 )
 {
    // Set the data:


### PR DESCRIPTION
In some examples, the [conventional](https://learn.microsoft.com/en-us/cpp/cpp/main-function-command-line-args?view=msvc-170#the-main-function-signature) naming of the typical two arguments to main() is flipped.
This is addressed in this PR.