### PR TITLE
FGMRES refinement for Primal Dual System

### DIFF
--- a/src/Algorithm/IpPDFullSpaceSolver.cpp
+++ b/src/Algorithm/IpPDFullSpaceSolver.cpp
@@ -1195,6 +1195,12 @@ bool PDFullSpaceSolver::GMRES(
 {
    DBG_START_METH("PDFullSpaceSolver::GMRES", dbg_verbosity);
 
+   // A larger GMRES restart is often better for convergence, but
+   // convergence should be fast since we use a direct solver as
+   // preconditioner. And restarting can improve attainable accuracy,
+   // see: Buttari, Alfredo, Nicholas J. Higham, Theo Mary, and
+   // Bastien Vieuble. "A modular framework for the backward error
+   // analysis of GMRES." (2024).
    Index restart = 3;
    if( restart > max_refinement_steps_ )
    {

--- a/src/Algorithm/IpPDFullSpaceSolver.cpp
+++ b/src/Algorithm/IpPDFullSpaceSolver.cpp
@@ -1254,18 +1254,9 @@ bool PDFullSpaceSolver::GMRES(
       // norm-wise relative backward error, Inf norm
       Number NRBE_inf = ComputeResidualRatio( rhs, res, *V[0], A_nrm_inf );
 
-      Number resid_nrm_max = resid.Amax();
-      std::cout << "GMRES it = " << totit << std::endl
-                << "  norm-wise backward error = " << NRBE_inf << std::endl
-                << "  ||r||2 = " << rho << std::endl
-                << "  ||r||2/||b||2 = " << rho / b_nrm_2 << std::endl
-                << "  ||r||Inf = " << resid_nrm_max << std::endl
-                << "  ||r||Inf/||b||Inf = " << resid_nrm_max / b_nrm_max << std::endl
-                << "  ||A||Inf = " << A_nrm_inf << std::endl;
-
       if( Jnlst().ProduceOutput(J_DETAILED, J_LINEAR_ALGEBRA) )
       {
-         // Number resid_nrm_max = resid.Amax();
+         Number resid_nrm_max = resid.Amax();
          Jnlst().Printf(J_DETAILED, J_LINEAR_ALGEBRA,
                         "GMRES it = %d\n", totit);
          Jnlst().Printf(J_DETAILED, J_LINEAR_ALGEBRA,
@@ -1350,20 +1341,10 @@ bool PDFullSpaceSolver::GMRES(
                           slack_s_L, slack_s_U, sigma_x, sigma_s, -1., 1., rhs, res, resid);
          NRBE_inf = ComputeResidualRatio( rhs, res, resid, A_nrm_inf );
 
-         Number resid_nrm_2 = resid.Nrm2();
-         Number resid_nrm_max = resid.Amax();
-         std::cout << "GMRES it = " << totit << std::endl
-                   << "  norm-wise backward error = " << NRBE_inf << std::endl
-                   << "  ||r||2 = " << resid_nrm_2 << std::endl
-                   << "  ||r||2/||b||2 = " << resid_nrm_2 / b_nrm_2 << std::endl
-                   << "  ||r||Inf = " << resid_nrm_max << std::endl
-                   << "  ||r||Inf/||b||Inf = " << resid_nrm_max / b_nrm_max << std::endl
-                   << "  ||A||Inf = " << A_nrm_inf << std::endl;
-
          if( Jnlst().ProduceOutput(J_DETAILED, J_LINEAR_ALGEBRA) )
          {
-            // Number resid_nrm_2 = resid.Nrm2();
-            // Number resid_nrm_max = resid.Amax();
+            Number resid_nrm_2 = resid.Nrm2();
+            Number resid_nrm_max = resid.Amax();
             Jnlst().Printf(J_DETAILED, J_LINEAR_ALGEBRA,
                            "GMRES it = %d\n", totit);
             Jnlst().Printf(J_DETAILED, J_LINEAR_ALGEBRA,

--- a/src/Algorithm/IpPDFullSpaceSolver.cpp
+++ b/src/Algorithm/IpPDFullSpaceSolver.cpp
@@ -1102,9 +1102,10 @@ bool PDFullSpaceSolver::GMRES(
    auto NullVec = res.MakeNewIteratesVectorCopy();
    NullVec->Set( 0. );
 
-   int restart = 500, totit = 0, ldH = restart + 1;
+   Index restart = 10;
    if (restart > max_refinement_steps_)
      restart = max_refinement_steps_;
+   Index totit = 0, ldH = restart + 1;
    bool done = false;
    Number tol = residual_ratio_max_, rho0 = 0., rho;
    while ( !done )
@@ -1155,7 +1156,7 @@ bool PDFullSpaceSolver::GMRES(
          V[it+1]->Set( 0. );
          ComputeResiduals(W, J_c, J_d, Px_L, Px_U, Pd_L, Pd_U, z_L, z_U, v_L, v_U, slack_x_L, slack_x_U,
                           slack_s_L, slack_s_U, sigma_x, sigma_s, -1., 1., *NullVec, *Z[it], *V[it+1]);
-         // for( Index reps=0; reps<2; reps++ )
+         for( Index reps=0; reps<2; reps++ )
          {
             for( Index k=0; k<=it; k++ )
             {
@@ -1210,7 +1211,6 @@ bool PDFullSpaceSolver::GMRES(
    if ( totit < max_refinement_steps_ &&
         ( resid.Nrm2() / rhs.Nrm2() < tol ) )
    {
-      std::cout << "Accepting GMRES solution" << std::endl;
       res.Copy( *x );
       return true;
    }
@@ -1218,7 +1218,6 @@ bool PDFullSpaceSolver::GMRES(
    {
       return false;
    }
-   //return totit < max_refinement_steps_;
 }
 
 } // namespace Ipopt

--- a/src/Algorithm/IpPDFullSpaceSolver.cpp
+++ b/src/Algorithm/IpPDFullSpaceSolver.cpp
@@ -1152,7 +1152,7 @@ Number PDFullSpaceSolver::NrmInf(
    Px_L.ComputeColA1(*tmp.z_L_NonConst());
    tmp.z_L_NonConst()->ElementWiseMultiply(z_L);
    tmp.z_L_NonConst()->ElementWiseAbs();
-   auto tmp_slack_x_L = slack_x_L.MakeNewCopy();
+   SmartPtr<Vector> tmp_slack_x_L = slack_x_L.MakeNewCopy();
    tmp_slack_x_L->ElementWiseAbs();
    tmp.z_L_NonConst()->Axpy(1., *tmp_slack_x_L);
    A_inf = std::max(A_inf, tmp.z_L_NonConst()->Amax());
@@ -1160,7 +1160,7 @@ Number PDFullSpaceSolver::NrmInf(
    Px_U.ComputeColA1(*tmp.z_U_NonConst());
    tmp.z_U_NonConst()->ElementWiseMultiply(z_U);
    tmp.z_U_NonConst()->ElementWiseAbs();
-   auto tmp_slack_x_U = slack_x_U.MakeNewCopy();
+   SmartPtr<Vector> tmp_slack_x_U = slack_x_U.MakeNewCopy();
    tmp_slack_x_U->ElementWiseAbs();
    tmp.z_U_NonConst()->Axpy(1., *tmp_slack_x_U);
    A_inf = std::max(A_inf, tmp.z_U_NonConst()->Amax());
@@ -1168,7 +1168,7 @@ Number PDFullSpaceSolver::NrmInf(
    Pd_L.ComputeColA1(*tmp.v_L_NonConst());
    tmp.v_L_NonConst()->ElementWiseMultiply(v_L);
    tmp.v_L_NonConst()->ElementWiseAbs();
-   auto tmp_slack_s_L = slack_s_L.MakeNewCopy();
+   SmartPtr<Vector> tmp_slack_s_L = slack_s_L.MakeNewCopy();
    tmp_slack_s_L->ElementWiseAbs();
    tmp.v_L_NonConst()->Axpy(1., *tmp_slack_s_L);
    A_inf = std::max(A_inf, tmp.v_L_NonConst()->Amax());
@@ -1176,7 +1176,7 @@ Number PDFullSpaceSolver::NrmInf(
    Pd_U.ComputeColA1(*tmp.v_U_NonConst());
    tmp.v_U_NonConst()->ElementWiseMultiply(v_U);
    tmp.v_U_NonConst()->ElementWiseAbs();
-   auto tmp_slack_s_U = slack_s_U.MakeNewCopy();
+   SmartPtr<Vector> tmp_slack_s_U = slack_s_U.MakeNewCopy();
    tmp_slack_s_U->ElementWiseAbs();
    tmp.v_U_NonConst()->Axpy(1., *tmp_slack_s_U);
    A_inf = std::max(A_inf, tmp.v_U_NonConst()->Amax());
@@ -1240,7 +1240,7 @@ bool PDFullSpaceSolver::GMRES(
    {
       std::vector<Number> givens_c(restart), givens_s(restart),
         b_(restart+1), H(restart*(restart+1));
-      std::vector<SmartPtr<IteratesVector>> V, Z;
+      std::vector<SmartPtr<IteratesVector> > V, Z;
       V.emplace_back(rhs.MakeNewIteratesVector());
       V[0]->Set( 0. );
       if ( !improve_solution )
@@ -1306,7 +1306,7 @@ bool PDFullSpaceSolver::GMRES(
          }
          for( Index k=0; k<=it; k++ )
          {
-            auto tmp = V[it+1]->Dot( *V[k] );
+            Number tmp = V[it+1]->Dot( *V[k] );
             H[k+it*ldH] += tmp;
             V[it+1]->Axpy( -tmp, *V[k] );
          }
@@ -1317,11 +1317,11 @@ bool PDFullSpaceSolver::GMRES(
          }
          for( Index k = 1; k < it+1; k++ )
          {
-            auto gamma = givens_c[k-1]*H[k-1+it*ldH] + givens_s[k-1]*H[k+it*ldH];
+            Number gamma = givens_c[k-1]*H[k-1+it*ldH] + givens_s[k-1]*H[k+it*ldH];
             H[k+it*ldH] = -givens_s[k-1]*H[k-1+it*ldH] + givens_c[k-1]*H[k+it*ldH];
             H[k-1+it*ldH] = gamma;
          }
-         auto delta = std::sqrt( H[it+it*ldH]*H[it+it*ldH] + H[it+1+it*ldH]*H[it+1+it*ldH] );
+         Number delta = std::sqrt( H[it+it*ldH]*H[it+it*ldH] + H[it+1+it*ldH]*H[it+1+it*ldH] );
          givens_c[it] = H[it+it*ldH] / delta;
          givens_s[it] = H[it+1+it*ldH] / delta;
          H[it+it*ldH] = givens_c[it]*H[it+it*ldH] + givens_s[it]*H[it+1+it*ldH];

--- a/src/Algorithm/IpPDFullSpaceSolver.cpp
+++ b/src/Algorithm/IpPDFullSpaceSolver.cpp
@@ -1273,7 +1273,8 @@ bool PDFullSpaceSolver::GMRES(
                         "  ||A||Inf = %e\n", A_nrm_inf);
       }
 
-      if( NRBE_inf < tol && totit >= min_refinement_steps_)
+      if( ( NRBE_inf < tol && totit >= min_refinement_steps_ ) ||
+          rho < std::numeric_limits<Number>::epsilon() )
       {
          resid.Copy( *V[0] );
          done = true;

--- a/src/Algorithm/IpPDFullSpaceSolver.cpp
+++ b/src/Algorithm/IpPDFullSpaceSolver.cpp
@@ -8,7 +8,6 @@
 #include "IpDebug.hpp"
 
 #include <cmath>
-#include <iomanip>
 
 namespace Ipopt
 {

--- a/src/Algorithm/IpPDFullSpaceSolver.cpp
+++ b/src/Algorithm/IpPDFullSpaceSolver.cpp
@@ -1230,30 +1230,15 @@ bool PDFullSpaceSolver::GMRES(
          rho0 = rho;
       }
       Number resid_nrm_max = resid.Amax();
-      // norm-wise relative backward error, in 2 or Inf norm
-      // Number NRBE_2 = rho / ( A_nrm_inf * x->Nrm2() + b_nrm_2 );
+      // norm-wise relative backward error
       Number NRBE_inf = resid_nrm_max / ( A_nrm_inf * x->Amax() /*+ b_nrm_max*/ );
-      // Number NRBE_inf = ComputeResidualRatio(rhs, *x, *V[0], A_nrm_inf);
-      // auto abs_resid = V[0]->MakeNewIteratesVectorCopy();
-      // auto abs_rhs = rhs.MakeNewIteratesVectorCopy();
-      // auto abs_x = x->MakeNewIteratesVectorCopy();
-      // abs_resid->ElementWiseAbs();
-      // abs_rhs->ElementWiseAbs();
-      // abs_x->ElementWiseAbs();
-      // abs_rhs->Axpy(A_nrm_inf, *abs_x);
-      // abs_rhs->AddScalar(Number(1.e-16));
-      // abs_resid->ElementWiseDivide(*abs_rhs);
-      // Number CRBE = abs_resid->Amax();
       std::cout << "GMRES it. "           << totit
-                // << "  NRBE_2= "            << std::setw(8) << NRBE_2
                 << "  NRBE_inf= "          << std::setw(8) << NRBE_inf
-                // << "  CRBE= "              << std::setw(8) << CRBE
                 << "  ||r||2= "            << std::setw(8) << rho
                 << "  ||r||2/||b||2= "     << std::setw(8) << rho / b_nrm_2
                 << "  ||r||Inf= "          << std::setw(8) << resid_nrm_max
                 << "  ||r||Inf/||b||Inf= " << std::setw(8) << resid_nrm_max / b_nrm_max
                 << "  ||A||Inf= "          << std::setw(8) << A_nrm_inf
-                // << "  ||b||Inf= "          << std::setw(8) << b_nrm_max
                 << std::endl;
       if( NRBE_inf < tol && totit >= min_refinement_steps_)
       {
@@ -1263,7 +1248,6 @@ bool PDFullSpaceSolver::GMRES(
       }
       V[0]->Scal( 1./rho );
       b_[0] = rho;
-      // int nrit = restart - 1;
       for( Index it = 0; it < restart; it++ )
       {
          totit++;
@@ -1324,26 +1308,13 @@ bool PDFullSpaceSolver::GMRES(
                           slack_s_L, slack_s_U, sigma_x, sigma_s, -1., 1., rhs, *x, resid);
          Number resid_nrm_2 = resid.Nrm2();
          resid_nrm_max = resid.Amax();
-         // NRBE_2 = resid_nrm_2 / ( A_nrm_inf * x->Nrm2() + b_nrm_2 );
          NRBE_inf = resid_nrm_max / ( A_nrm_inf * x->Amax() /*+ b_nrm_max*/ );
-         // NRBE_inf = ComputeResidualRatio(rhs, *x, resid, A_nrm_inf);
-         // abs_resid->Copy( resid );
-         // abs_x->Copy( *x );
-         // abs_resid->ElementWiseAbs();
-         // abs_x->ElementWiseAbs();
-         // abs_rhs->Axpy(A_nrm_inf, *abs_x);
-         // abs_rhs->AddScalar(Number(1.e-16));
-         // abs_resid->ElementWiseDivide(*abs_rhs);
-         // Number CRBE = abs_resid->Amax();
          std::cout << "GMRES it. "           << totit
-                   // << "  NRBE_2= "            << std::setw(8) << NRBE_2
                    << "  NRBE_inf= "          << std::setw(8) << NRBE_inf
-                   // << "  CRBE= "              << std::setw(8) << CRBE
                    << "  ||r||2= "            << std::setw(8) << resid_nrm_2
                    << "  ||r||2/||b||2= "     << std::setw(8) << resid_nrm_2 / b_nrm_2
                    << "  ||r||Inf= "          << std::setw(8) << resid_nrm_max
                    << "  ||r||Inf/||b||Inf= " << std::setw(8) << resid_nrm_max / b_nrm_max
-                   // << "  rho= "               << std::setw(8) << rho
                    << std::endl;
          if( (NRBE_inf < tol && totit >= min_refinement_steps_) ||
              (totit >= max_refinement_steps_) )

--- a/src/Algorithm/IpPDFullSpaceSolver.cpp
+++ b/src/Algorithm/IpPDFullSpaceSolver.cpp
@@ -1257,7 +1257,7 @@ bool PDFullSpaceSolver::GMRES(
       Number resid_nrm_max = resid.Amax();
       std::cout << "GMRES it = " << totit << std::endl
                 << "  norm-wise backward error = " << NRBE_inf << std::endl
-                << "  ||r||2 = resid_nrm_2" << std::endl
+                << "  ||r||2 = " << rho << std::endl
                 << "  ||r||2/||b||2 = " << rho / b_nrm_2 << std::endl
                 << "  ||r||Inf = " << resid_nrm_max << std::endl
                 << "  ||r||Inf/||b||Inf = " << resid_nrm_max / b_nrm_max << std::endl
@@ -1283,6 +1283,7 @@ bool PDFullSpaceSolver::GMRES(
       }
 
       if( ( NRBE_inf < tol && totit >= min_refinement_steps_ ) ||
+            NRBE_inf < std::numeric_limits<Number>::epsilon() ||
           rho < std::numeric_limits<Number>::epsilon() )
       {
          resid.Copy( *V[0] );
@@ -1353,7 +1354,7 @@ bool PDFullSpaceSolver::GMRES(
          Number resid_nrm_max = resid.Amax();
          std::cout << "GMRES it = " << totit << std::endl
                    << "  norm-wise backward error = " << NRBE_inf << std::endl
-                   << "  ||r||2 = resid_nrm_2" << std::endl
+                   << "  ||r||2 = " << resid_nrm_2 << std::endl
                    << "  ||r||2/||b||2 = " << resid_nrm_2 / b_nrm_2 << std::endl
                    << "  ||r||Inf = " << resid_nrm_max << std::endl
                    << "  ||r||Inf/||b||Inf = " << resid_nrm_max / b_nrm_max << std::endl
@@ -1379,6 +1380,7 @@ bool PDFullSpaceSolver::GMRES(
                            "  ||A||Inf = %e\n", A_nrm_inf);
          }
          if( (NRBE_inf < tol && totit >= min_refinement_steps_) ||
+              NRBE_inf < std::numeric_limits<Number>::epsilon() ||
              (totit >= max_refinement_steps_) )
          {
             done = true;

--- a/src/Algorithm/IpPDFullSpaceSolver.cpp
+++ b/src/Algorithm/IpPDFullSpaceSolver.cpp
@@ -1254,9 +1254,18 @@ bool PDFullSpaceSolver::GMRES(
       // norm-wise relative backward error, Inf norm
       Number NRBE_inf = ComputeResidualRatio( rhs, res, *V[0], A_nrm_inf );
 
+      Number resid_nrm_max = resid.Amax();
+      std::cout << "GMRES it = " << totit << std::endl
+                << "  norm-wise backward error = " << NRBE_inf << std::endl
+                << "  ||r||2 = resid_nrm_2" << std::endl
+                << "  ||r||2/||b||2 = " << rho / b_nrm_2 << std::endl
+                << "  ||r||Inf = " << resid_nrm_max << std::endl
+                << "  ||r||Inf/||b||Inf = " << resid_nrm_max / b_nrm_max << std::endl
+                << "  ||A||Inf = " << A_nrm_inf << std::endl;
+
       if( Jnlst().ProduceOutput(J_DETAILED, J_LINEAR_ALGEBRA) )
       {
-         Number resid_nrm_max = resid.Amax();
+         // Number resid_nrm_max = resid.Amax();
          Jnlst().Printf(J_DETAILED, J_LINEAR_ALGEBRA,
                         "GMRES it = %d\n", totit);
          Jnlst().Printf(J_DETAILED, J_LINEAR_ALGEBRA,
@@ -1340,10 +1349,20 @@ bool PDFullSpaceSolver::GMRES(
                           slack_s_L, slack_s_U, sigma_x, sigma_s, -1., 1., rhs, res, resid);
          NRBE_inf = ComputeResidualRatio( rhs, res, resid, A_nrm_inf );
 
+         Number resid_nrm_2 = resid.Nrm2();
+         Number resid_nrm_max = resid.Amax();
+         std::cout << "GMRES it = " << totit << std::endl
+                   << "  norm-wise backward error = " << NRBE_inf << std::endl
+                   << "  ||r||2 = resid_nrm_2" << std::endl
+                   << "  ||r||2/||b||2 = " << resid_nrm_2 / b_nrm_2 << std::endl
+                   << "  ||r||Inf = " << resid_nrm_max << std::endl
+                   << "  ||r||Inf/||b||Inf = " << resid_nrm_max / b_nrm_max << std::endl
+                   << "  ||A||Inf = " << A_nrm_inf << std::endl;
+
          if( Jnlst().ProduceOutput(J_DETAILED, J_LINEAR_ALGEBRA) )
          {
-            Number resid_nrm_2 = resid.Nrm2();
-            Number resid_nrm_max = resid.Amax();
+            // Number resid_nrm_2 = resid.Nrm2();
+            // Number resid_nrm_max = resid.Amax();
             Jnlst().Printf(J_DETAILED, J_LINEAR_ALGEBRA,
                            "GMRES it = %d\n", totit);
             Jnlst().Printf(J_DETAILED, J_LINEAR_ALGEBRA,

--- a/src/Algorithm/IpPDFullSpaceSolver.cpp
+++ b/src/Algorithm/IpPDFullSpaceSolver.cpp
@@ -1141,13 +1141,13 @@ Number PDFullSpaceSolver::NrmInf(
 
    Pd_L.ComputeRowA1(*tmp.s_NonConst());
    Pd_U.ComputeRowA1(*tmp.s_NonConst(), false);
-   A_inf = std::max(A_inf, tmp.s_NonConst()->Amax() + 1. + delta_s);
+   A_inf = std::max(A_inf, tmp.s_NonConst()->Amax() + Number(1.) + delta_s);
 
    J_c.ComputeRowA1(*tmp.y_c_NonConst());
    A_inf = std::max(A_inf, tmp.y_c_NonConst()->Amax() + delta_c);
 
    J_d.ComputeRowA1(*tmp.y_d_NonConst());
-   A_inf = std::max(A_inf, tmp.y_d_NonConst()->Amax() + 1. + delta_d);
+   A_inf = std::max(A_inf, tmp.y_d_NonConst()->Amax() + Number(1.) + delta_d);
 
    Px_L.ComputeColA1(*tmp.z_L_NonConst());
    tmp.z_L_NonConst()->ElementWiseMultiply(z_L);

--- a/src/Algorithm/IpPDFullSpaceSolver.cpp
+++ b/src/Algorithm/IpPDFullSpaceSolver.cpp
@@ -1152,7 +1152,7 @@ Number PDFullSpaceSolver::NrmInf(
    Px_L.ComputeColA1(*tmp.z_L_NonConst());
    tmp.z_L_NonConst()->ElementWiseMultiply(z_L);
    tmp.z_L_NonConst()->ElementWiseAbs();
-   auto tmp_slack_x_L = slack_x_L.MakeNewCopy();
+   SmartPtr<Vector> tmp_slack_x_L = slack_x_L.MakeNewCopy();
    tmp_slack_x_L->ElementWiseAbs();
    tmp.z_L_NonConst()->Axpy(1., *tmp_slack_x_L);
    A_inf = std::max(A_inf, tmp.z_L_NonConst()->Amax());
@@ -1160,7 +1160,7 @@ Number PDFullSpaceSolver::NrmInf(
    Px_U.ComputeColA1(*tmp.z_U_NonConst());
    tmp.z_U_NonConst()->ElementWiseMultiply(z_U);
    tmp.z_U_NonConst()->ElementWiseAbs();
-   auto tmp_slack_x_U = slack_x_U.MakeNewCopy();
+   SmartPtr<Vector> tmp_slack_x_U = slack_x_U.MakeNewCopy();
    tmp_slack_x_U->ElementWiseAbs();
    tmp.z_U_NonConst()->Axpy(1., *tmp_slack_x_U);
    A_inf = std::max(A_inf, tmp.z_U_NonConst()->Amax());
@@ -1168,7 +1168,7 @@ Number PDFullSpaceSolver::NrmInf(
    Pd_L.ComputeColA1(*tmp.v_L_NonConst());
    tmp.v_L_NonConst()->ElementWiseMultiply(v_L);
    tmp.v_L_NonConst()->ElementWiseAbs();
-   auto tmp_slack_s_L = slack_s_L.MakeNewCopy();
+   SmartPtr<Vector> tmp_slack_s_L = slack_s_L.MakeNewCopy();
    tmp_slack_s_L->ElementWiseAbs();
    tmp.v_L_NonConst()->Axpy(1., *tmp_slack_s_L);
    A_inf = std::max(A_inf, tmp.v_L_NonConst()->Amax());
@@ -1176,7 +1176,7 @@ Number PDFullSpaceSolver::NrmInf(
    Pd_U.ComputeColA1(*tmp.v_U_NonConst());
    tmp.v_U_NonConst()->ElementWiseMultiply(v_U);
    tmp.v_U_NonConst()->ElementWiseAbs();
-   auto tmp_slack_s_U = slack_s_U.MakeNewCopy();
+   SmartPtr<Vector> tmp_slack_s_U = slack_s_U.MakeNewCopy();
    tmp_slack_s_U->ElementWiseAbs();
    tmp.v_U_NonConst()->Axpy(1., *tmp_slack_s_U);
    A_inf = std::max(A_inf, tmp.v_U_NonConst()->Amax());
@@ -1236,11 +1236,14 @@ bool PDFullSpaceSolver::GMRES(
    Number b_nrm_2 = rhs.Nrm2(), b_nrm_max = rhs.Amax();
    Number A_nrm_inf = NrmInf(W, J_c, J_d, Px_L, Px_U, Pd_L, Pd_U, z_L, z_U, v_L, v_U,
                              slack_x_L, slack_x_U, slack_s_L, slack_s_U, resid);
+   // for first loop
+   Number residual_ratio_old = std::numeric_limits<Number>::max();
+   Number NRBE_inf = std::numeric_limits<Number>::max();
    while ( !done )
    {
       std::vector<Number> givens_c(restart), givens_s(restart),
         b_(restart+1), H(restart*(restart+1));
-      std::vector<SmartPtr<IteratesVector>> V, Z;
+      std::vector<SmartPtr<IteratesVector> > V, Z;
       V.emplace_back(rhs.MakeNewIteratesVector());
       V[0]->Set( 0. );
       if ( !improve_solution )
@@ -1251,8 +1254,9 @@ bool PDFullSpaceSolver::GMRES(
                        slack_s_L, slack_s_U, sigma_x, sigma_s, -1., 1., rhs, res, *V[0]);
       improve_solution = true;  // after restart, improve res from previous cycle
       Number rho = V[0]->Nrm2();
+      residual_ratio_old = NRBE_inf;
       // norm-wise relative backward error, Inf norm
-      Number NRBE_inf = ComputeResidualRatio( rhs, res, *V[0], A_nrm_inf );
+      NRBE_inf = ComputeResidualRatio( rhs, res, *V[0], A_nrm_inf );
 
       Number resid_nrm_max = resid.Amax();
       std::cout << "GMRES it = " << totit << std::endl
@@ -1283,7 +1287,8 @@ bool PDFullSpaceSolver::GMRES(
       }
 
       if( ( NRBE_inf < tol && totit >= min_refinement_steps_ ) ||
-          rho < std::numeric_limits<Number>::epsilon() )
+          rho < std::numeric_limits<Number>::epsilon() ||
+          NRBE_inf > residual_improvement_factor_ * residual_ratio_old )
       {
          resid.Copy( *V[0] );
          done = true;
@@ -1314,7 +1319,7 @@ bool PDFullSpaceSolver::GMRES(
          }
          for( Index k=0; k<=it; k++ )
          {
-            auto tmp = V[it+1]->Dot( *V[k] );
+            Number tmp = V[it+1]->Dot( *V[k] );
             H[k+it*ldH] += tmp;
             V[it+1]->Axpy( -tmp, *V[k] );
          }
@@ -1325,11 +1330,11 @@ bool PDFullSpaceSolver::GMRES(
          }
          for( Index k = 1; k < it+1; k++ )
          {
-            auto gamma = givens_c[k-1]*H[k-1+it*ldH] + givens_s[k-1]*H[k+it*ldH];
+            Number gamma = givens_c[k-1]*H[k-1+it*ldH] + givens_s[k-1]*H[k+it*ldH];
             H[k+it*ldH] = -givens_s[k-1]*H[k-1+it*ldH] + givens_c[k-1]*H[k+it*ldH];
             H[k-1+it*ldH] = gamma;
          }
-         auto delta = std::sqrt( H[it+it*ldH]*H[it+it*ldH] + H[it+1+it*ldH]*H[it+1+it*ldH] );
+         Number delta = std::sqrt( H[it+it*ldH]*H[it+it*ldH] + H[it+1+it*ldH]*H[it+1+it*ldH] );
          givens_c[it] = H[it+it*ldH] / delta;
          givens_s[it] = H[it+1+it*ldH] / delta;
          H[it+it*ldH] = givens_c[it]*H[it+it*ldH] + givens_s[it]*H[it+1+it*ldH];
@@ -1347,6 +1352,7 @@ bool PDFullSpaceSolver::GMRES(
 
          ComputeResiduals(W, J_c, J_d, Px_L, Px_U, Pd_L, Pd_U, z_L, z_U, v_L, v_U, slack_x_L, slack_x_U,
                           slack_s_L, slack_s_U, sigma_x, sigma_s, -1., 1., rhs, res, resid);
+         residual_ratio_old = NRBE_inf;
          NRBE_inf = ComputeResidualRatio( rhs, res, resid, A_nrm_inf );
 
          Number resid_nrm_2 = resid.Nrm2();
@@ -1379,7 +1385,8 @@ bool PDFullSpaceSolver::GMRES(
                            "  ||A||Inf = %e\n", A_nrm_inf);
          }
          if( (NRBE_inf < tol && totit >= min_refinement_steps_) ||
-             (totit >= max_refinement_steps_) )
+             (totit >= max_refinement_steps_) ||
+             (NRBE_inf > residual_improvement_factor_ * residual_ratio_old ) )
          {
             done = true;
             break;

--- a/src/Algorithm/IpPDFullSpaceSolver.cpp
+++ b/src/Algorithm/IpPDFullSpaceSolver.cpp
@@ -975,7 +975,7 @@ void PDFullSpaceSolver::ComputeResiduals(
 
    // d
    J_d.MultVector(1., *res.x(), 0., *resid.y_d_NonConst());
-   resid.y_d_NonConst()->AddTwoVectors(alpha, *res.s(), beta, *rhs.y_d(), alpha);
+   resid.y_d_NonConst()->AddTwoVectors(-alpha, *res.s(), beta, *rhs.y_d(), alpha);
    if( delta_d != 0. )
    {
       resid.y_d_NonConst()->Axpy(-alpha*delta_d, *res.y_d());

--- a/src/Algorithm/IpPDFullSpaceSolver.cpp
+++ b/src/Algorithm/IpPDFullSpaceSolver.cpp
@@ -1156,12 +1156,19 @@ bool PDFullSpaceSolver::GMRES(
          V[it+1]->Set( 0. );
          ComputeResiduals(W, J_c, J_d, Px_L, Px_U, Pd_L, Pd_U, z_L, z_U, v_L, v_U, slack_x_L, slack_x_U,
                           slack_s_L, slack_s_U, sigma_x, sigma_s, -1., 1., *NullVec, *Z[it], *V[it+1]);
-         for( Index reps=0; reps<2; reps++ )
          {
             for( Index k=0; k<=it; k++ )
             {
                H[k+it*ldH] = V[it+1]->Dot( *V[k] );
                V[it+1]->Axpy( -H[k+it*ldH], *V[k] );
+            }
+         }
+         {  // second time for numerical stability, ToDo optional?
+            for( Index k=0; k<=it; k++ )
+            {
+              auto tmp = V[it+1]->Dot( *V[k] );
+              H[k+it*ldH] += tmp;
+              V[it+1]->Axpy( -tmp, *V[k] );
             }
          }
          H[it+1+it*ldH] = V[it+1]->Nrm2();

--- a/src/Algorithm/IpPDFullSpaceSolver.hpp
+++ b/src/Algorithm/IpPDFullSpaceSolver.hpp
@@ -224,6 +224,42 @@ private:
       Vector&       X
    );
    ///@}
+
+   bool SolveGMRES(
+      Number                alpha,
+      Number                beta,
+      const IteratesVector& rhs,
+      IteratesVector&       res,
+      bool                  allow_inexact = false,
+      bool                  improve_solution = false
+   );
+
+   bool GMRES(
+      const SymMatrix&      W,
+      const Matrix&         J_c,
+      const Matrix&         J_d,
+      const Matrix&         Px_L,
+      const Matrix&         Px_U,
+      const Matrix&         Pd_L,
+      const Matrix&         Pd_U,
+      const Vector&         z_L,
+      const Vector&         z_U,
+      const Vector&         v_L,
+      const Vector&         v_U,
+      const Vector&         slack_x_L,
+      const Vector&         slack_x_U,
+      const Vector&         slack_s_L,
+      const Vector&         slack_s_U,
+      const Vector&         sigma_x,
+      const Vector&         sigma_s,
+      const IteratesVector& rhs,
+      IteratesVector&       res,
+      IteratesVector&       resid,
+      bool                  improve_solution,
+      bool                  resolve_with_better_quality,
+      bool                  pretend_singular,
+      bool&                 solve_retval
+   );
 };
 
 } // namespace Ipopt

--- a/src/Algorithm/IpPDFullSpaceSolver.hpp
+++ b/src/Algorithm/IpPDFullSpaceSolver.hpp
@@ -132,6 +132,9 @@ private:
     */
    Number residual_improvement_factor_;
 
+   /** Use (flexible) GMRES refinement instead of iterative refinement */
+   bool gmres_refinement_;
+
    /** Tolerance for heuristic to ignore wrong inertia */
    Number neg_curv_test_tol_;
 
@@ -208,7 +211,8 @@ private:
    Number ComputeResidualRatio(
       const IteratesVector& rhs,
       const IteratesVector& res,
-      const IteratesVector& resid
+      const IteratesVector& resid,
+      Number AInfNrm
    );
 
    /** @name Auxiliary functions */
@@ -260,6 +264,26 @@ private:
       bool                  pretend_singular,
       bool&                 solve_retval
    );
+
+   Number NrmInf(
+      const SymMatrix& W,
+      const Matrix&    J_c,
+      const Matrix&    J_d,
+      const Matrix&    Px_L,
+      const Matrix&    Px_U,
+      const Matrix&    Pd_L,
+      const Matrix&    Pd_U,
+      const Vector&    z_L,
+      const Vector&    z_U,
+      const Vector&    v_L,
+      const Vector&    v_U,
+      const Vector&    slack_x_L,
+      const Vector&    slack_x_U,
+      const Vector&    slack_s_L,
+      const Vector&    slack_s_U,
+      IteratesVector&  tmp
+   );
+
 };
 
 } // namespace Ipopt

--- a/src/LinAlg/IpCompoundMatrix.cpp
+++ b/src/LinAlg/IpCompoundMatrix.cpp
@@ -715,6 +715,118 @@ void CompoundMatrix::ComputeColAMaxImpl(
    }
 }
 
+void CompoundMatrix::ComputeRowA1Impl(
+   Vector& rows_norms,
+   bool    /*init*/
+) const
+{
+   if( !matrices_valid_ )
+   {
+      matrices_valid_ = MatricesValid();
+   }
+   DBG_ASSERT(matrices_valid_);
+
+   // The vector is assumed to be compound Vectors as well except if
+   // there is only one component
+   CompoundVector* comp_vec = dynamic_cast<CompoundVector*>(&rows_norms);
+
+#ifndef ALLOW_NESTED
+   //  A few sanity checks
+   if (comp_vec)
+   {
+      DBG_ASSERT(NComps_Rows() == comp_vec->NComps());
+   }
+   else
+   {
+      DBG_ASSERT(NComps_Rows() == 1);
+   }
+#endif
+   if( comp_vec )
+   {
+      if( NComps_Rows() != comp_vec->NComps() )
+      {
+         comp_vec = NULL;
+      }
+   }
+
+   for( Index jcol = 0; jcol < NComps_Cols(); jcol++ )
+   {
+      for( Index irow = 0; irow < NComps_Rows(); irow++ )
+      {
+         if( ConstComp(irow, jcol) )
+         {
+            SmartPtr<Vector> vec_i;
+            if( comp_vec )
+            {
+               vec_i = comp_vec->GetCompNonConst(irow);
+            }
+            else
+            {
+               vec_i = &rows_norms;
+            }
+            DBG_ASSERT(IsValid(vec_i));
+            ConstComp(irow, jcol)->ComputeRowA1(*vec_i, false);
+         }
+      }
+   }
+}
+
+void CompoundMatrix::ComputeColA1Impl(
+   Vector& cols_norms,
+   bool    /*init*/
+) const
+{
+   if( !matrices_valid_ )
+   {
+      matrices_valid_ = MatricesValid();
+   }
+   DBG_ASSERT(matrices_valid_);
+
+   // The vector is assumed to be compound Vectors as well except if
+   // there is only one component
+   CompoundVector* comp_vec = dynamic_cast<CompoundVector*>(&cols_norms);
+
+#ifndef ALLOW_NESTED
+   //  A few sanity checks
+   if (comp_vec)
+   {
+      DBG_ASSERT(NComps_Cols() == comp_vec->NComps());
+   }
+   else
+   {
+      DBG_ASSERT(NComps_Cols() == 1);
+   }
+#endif
+   if( comp_vec )
+   {
+      if( NComps_Cols() != comp_vec->NComps() )
+      {
+         comp_vec = NULL;
+      }
+   }
+
+   for( Index irow = 0; irow < NComps_Rows(); irow++ )
+   {
+      for( Index jcol = 0; jcol < NComps_Cols(); jcol++ )
+      {
+         if( ConstComp(irow, jcol) )
+         {
+            SmartPtr<Vector> vec_j;
+            if( comp_vec )
+            {
+               vec_j = comp_vec->GetCompNonConst(jcol);
+            }
+            else
+            {
+               vec_j = &cols_norms;
+            }
+            DBG_ASSERT(IsValid(vec_j));
+            ConstComp(irow, jcol)->ComputeColA1(*vec_j, false);
+         }
+      }
+   }
+}
+
 void CompoundMatrix::PrintImpl(
    const Journalist&  jnlst,
    EJournalLevel      level,

--- a/src/LinAlg/IpCompoundMatrix.hpp
+++ b/src/LinAlg/IpCompoundMatrix.hpp
@@ -155,6 +155,16 @@ protected:
       bool    init
    ) const;
 
+   virtual void ComputeRowA1Impl(
+      Vector& rows_norms,
+      bool    init
+   ) const;
+
+   virtual void ComputeColA1Impl(
+      Vector& cols_norms,
+      bool    init
+   ) const;
+
    virtual void PrintImpl(
       const Journalist&  jnlst,
       EJournalLevel      level,

--- a/src/LinAlg/IpCompoundSymMatrix.cpp
+++ b/src/LinAlg/IpCompoundSymMatrix.cpp
@@ -237,6 +237,57 @@ void CompoundSymMatrix::ComputeRowAMaxImpl(
    }
 }
 
+void CompoundSymMatrix::ComputeRowA1Impl(
+   Vector& rows_norms,
+   bool    /*init*/
+) const
+{
+   if( !matrices_valid_ )
+   {
+      matrices_valid_ = MatricesValid();
+   }
+   DBG_ASSERT(matrices_valid_);
+
+   // The vector is assumed to be compound Vectors as well except if
+   // there is only one component
+   CompoundVector* comp_vec = dynamic_cast<CompoundVector*>(&rows_norms);
+
+   //  A few sanity checks
+   if( comp_vec )
+   {
+      DBG_ASSERT(NComps_Dim() == comp_vec->NComps());
+   }
+   else
+   {
+      DBG_ASSERT(NComps_Dim() == 1);
+   }
+
+   for( Index jcol = 0; jcol < NComps_Dim(); jcol++ )
+   {
+      for( Index irow = 0; irow < NComps_Dim(); irow++ )
+      {
+         SmartPtr<Vector> vec_i;
+         if( comp_vec )
+         {
+            vec_i = comp_vec->GetCompNonConst(irow);
+         }
+         else
+         {
+            vec_i = &rows_norms;
+         }
+         DBG_ASSERT(IsValid(vec_i));
+         if( jcol <= irow && ConstComp(irow, jcol) )
+         {
+            ConstComp(irow, jcol)->ComputeRowA1(*vec_i, false);
+         }
+         else if( jcol > irow && ConstComp(jcol, irow) )
+         {
+            ConstComp(jcol, irow)->ComputeRowA1(*vec_i, false);
+         }
+      }
+   }
+}
+
 void CompoundSymMatrix::PrintImpl(
    const Journalist&  jnlst,
    EJournalLevel      level,

--- a/src/LinAlg/IpCompoundSymMatrix.hpp
+++ b/src/LinAlg/IpCompoundSymMatrix.hpp
@@ -117,6 +117,11 @@ protected:
       bool    init
    ) const;
 
+   virtual void ComputeRowA1Impl(
+      Vector& rows_norms,
+      bool    init
+   ) const;
+
    virtual void PrintImpl(
       const Journalist&  jnlst,
       EJournalLevel      level,

--- a/src/LinAlg/IpDenseGenMatrix.cpp
+++ b/src/LinAlg/IpDenseGenMatrix.cpp
@@ -415,6 +415,22 @@ void DenseGenMatrix::ComputeColAMaxImpl(
    }
 }
 
+void DenseGenMatrix::ComputeRowA1Impl(
+   Vector& /*rows_norms*/,
+   bool    /*init*/
+) const
+{
+   THROW_EXCEPTION(UNIMPLEMENTED_LINALG_METHOD_CALLED, "DenseGenMatrix::ComputeRowA1Impl not implemented");
+}
+
+void DenseGenMatrix::ComputeColA1Impl(
+   Vector& /*cols_norms*/,
+   bool    /*init*/
+) const
+{
+   THROW_EXCEPTION(UNIMPLEMENTED_LINALG_METHOD_CALLED, "DenseGenMatrix::ComputeColA1Impl not implemented");
+}
+
 bool DenseGenMatrix::HasValidNumbersImpl() const
 {
    DBG_ASSERT(initialized_);

--- a/src/LinAlg/IpDenseGenMatrix.hpp
+++ b/src/LinAlg/IpDenseGenMatrix.hpp
@@ -217,6 +217,16 @@ protected:
       bool    init
    ) const;
 
+   virtual void ComputeRowA1Impl(
+      Vector& rows_norms,
+      bool    init
+   ) const;
+
+   virtual void ComputeColA1Impl(
+      Vector& cols_norms,
+      bool    init
+   ) const;
+
    virtual void PrintImpl(
       const Journalist&  jnlst,
       EJournalLevel      level,

--- a/src/LinAlg/IpDenseSymMatrix.cpp
+++ b/src/LinAlg/IpDenseSymMatrix.cpp
@@ -254,6 +254,15 @@ void DenseSymMatrix::ComputeRowAMaxImpl(
    }
 }
 
+void DenseSymMatrix::ComputeRowA1Impl(
+   Vector& /*rows_norms*/,
+   bool    /*init*/
+) const
+{
+   THROW_EXCEPTION(UNIMPLEMENTED_LINALG_METHOD_CALLED, "DenseSymMatrix::ComputeRowA1Impl not implemented");
+}
+
+
 void DenseSymMatrix::PrintImpl(
    const Journalist&  jnlst,
    EJournalLevel      level,

--- a/src/LinAlg/IpDenseSymMatrix.hpp
+++ b/src/LinAlg/IpDenseSymMatrix.hpp
@@ -133,6 +133,11 @@ protected:
       bool    init
    ) const;
 
+   virtual void ComputeRowA1Impl(
+      Vector& rows_norms,
+      bool    init
+   ) const;
+
    virtual void PrintImpl(
       const Journalist&  jnlst,
       EJournalLevel      level,

--- a/src/LinAlg/IpDiagMatrix.cpp
+++ b/src/LinAlg/IpDiagMatrix.cpp
@@ -71,6 +71,25 @@ void DiagMatrix::ComputeRowAMaxImpl(
    }
 }
 
+void DiagMatrix::ComputeRowA1Impl(
+   Vector& rows_norms,
+   bool    init
+) const
+{
+   DBG_ASSERT(IsValid(diag_));
+   if( init )
+   {
+      rows_norms.Copy(*diag_);
+      rows_norms.ElementWiseAbs();
+   }
+   else
+   {
+      SmartPtr<Vector> v = diag_->MakeNewCopy();
+      v->ElementWiseAbs();
+      rows_norms.Axpy(Number(1.), *v);
+   }
+}
+
 void DiagMatrix::PrintImpl(
    const Journalist&  jnlst,
    EJournalLevel      level,

--- a/src/LinAlg/IpDiagMatrix.hpp
+++ b/src/LinAlg/IpDiagMatrix.hpp
@@ -63,6 +63,11 @@ protected:
       bool    init
    ) const;
 
+   virtual void ComputeRowA1Impl(
+      Vector& rows_norms,
+      bool    init
+   ) const;
+
    virtual void PrintImpl(
       const Journalist&  jnlst,
       EJournalLevel      level,

--- a/src/LinAlg/IpExpandedMultiVectorMatrix.cpp
+++ b/src/LinAlg/IpExpandedMultiVectorMatrix.cpp
@@ -192,6 +192,22 @@ void ExpandedMultiVectorMatrix::ComputeColAMaxImpl(
    THROW_EXCEPTION(UNIMPLEMENTED_LINALG_METHOD_CALLED, "ExpandedMultiVectorMatrix::ComputeColAMaxImpl not implemented");
 }
 
+void ExpandedMultiVectorMatrix::ComputeRowA1Impl(
+   Vector& /*rows_norms*/,
+   bool    /*init*/
+) const
+{
+   THROW_EXCEPTION(UNIMPLEMENTED_LINALG_METHOD_CALLED, "ExpandedMultiVectorMatrix::ComputeRowA1Impl not implemented");
+}
+
+void ExpandedMultiVectorMatrix::ComputeColA1Impl(
+   Vector& /*cols_norms*/,
+   bool    /*init*/
+) const
+{
+   THROW_EXCEPTION(UNIMPLEMENTED_LINALG_METHOD_CALLED, "ExpandedMultiVectorMatrix::ComputeColA1Impl not implemented");
+}
+
 void ExpandedMultiVectorMatrix::PrintImpl(
    const Journalist&  jnlst,
    EJournalLevel      level,

--- a/src/LinAlg/IpExpandedMultiVectorMatrix.hpp
+++ b/src/LinAlg/IpExpandedMultiVectorMatrix.hpp
@@ -101,7 +101,17 @@ protected:
       bool    init
    ) const;
 
-   virtual void PrintImpl(
+   virtual void ComputeRowA1Impl(
+      Vector& rows_norms,
+      bool    init
+   ) const;
+
+   virtual void ComputeColA1Impl(
+      Vector& cols_norms,
+      bool    init
+  ) const;
+
+  virtual void PrintImpl(
       const Journalist&  jnlst,
       EJournalLevel      level,
       EJournalCategory   category,

--- a/src/LinAlg/IpExpansionMatrix.cpp
+++ b/src/LinAlg/IpExpansionMatrix.cpp
@@ -405,6 +405,38 @@ void ExpansionMatrix::ComputeColAMaxImpl(
    }
 }
 
+void ExpansionMatrix::ComputeRowA1Impl(
+   Vector& rows_norms,
+   bool    /*init*/
+) const
+{
+   DenseVector* dense_vec = static_cast<DenseVector*>(&rows_norms);
+   DBG_ASSERT(dynamic_cast<DenseVector*>(&rows_norms));
+   Number* vec_vals = dense_vec->Values();
+
+   const Index* exp_pos = ExpandedPosIndices();
+
+   for( Index i = 0; i < NCols(); i++ )
+   {
+      vec_vals[exp_pos[i]] += Number(1.);
+   }
+}
+
+void ExpansionMatrix::ComputeColA1Impl(
+   Vector& cols_norms,
+   bool    init
+) const
+{
+   if( init )
+   {
+      cols_norms.Set(1.);
+   }
+   else
+   {
+      cols_norms.AddScalar(Number(1.));
+   }
+}
+
 void ExpansionMatrix::PrintImplOffset(
    const Journalist&  jnlst,
    EJournalLevel      level,

--- a/src/LinAlg/IpExpansionMatrix.hpp
+++ b/src/LinAlg/IpExpansionMatrix.hpp
@@ -103,6 +103,16 @@ protected:
       bool    init
    ) const;
 
+   virtual void ComputeRowA1Impl(
+      Vector& rows_norms,
+      bool    init
+   ) const;
+
+   virtual void ComputeColA1Impl(
+      Vector& cols_norms,
+      bool    init
+   ) const;
+
    virtual void PrintImpl(
       const Journalist&  jnlst,
       EJournalLevel      level,

--- a/src/LinAlg/IpIdentityMatrix.cpp
+++ b/src/LinAlg/IpIdentityMatrix.cpp
@@ -62,6 +62,21 @@ void IdentityMatrix::ComputeRowAMaxImpl(
    }
 }
 
+void IdentityMatrix::ComputeRowA1Impl(
+   Vector& rows_norms,
+   bool    init
+) const
+{
+   if( init )
+   {
+      rows_norms.Set(1.);
+   }
+   else
+   {
+      rows_norms.AddScalar(Number(1.));
+   }
+}
+
 void IdentityMatrix::PrintImpl(
    const Journalist&  jnlst,
    EJournalLevel      level,

--- a/src/LinAlg/IpIdentityMatrix.hpp
+++ b/src/LinAlg/IpIdentityMatrix.hpp
@@ -71,6 +71,11 @@ protected:
       bool    init
    ) const;
 
+   virtual void ComputeRowA1Impl(
+      Vector& rows_norms,
+      bool    init
+   ) const;
+
    virtual void PrintImpl(
       const Journalist&  jnlst,
       EJournalLevel      level,

--- a/src/LinAlg/IpLowRankUpdateSymMatrix.cpp
+++ b/src/LinAlg/IpLowRankUpdateSymMatrix.cpp
@@ -170,6 +170,22 @@ void LowRankUpdateSymMatrix::ComputeColAMaxImpl(
    THROW_EXCEPTION(UNIMPLEMENTED_LINALG_METHOD_CALLED, "LowRankUpdateSymMatrix::ComputeColAMaxImpl not implemented");
 }
 
+void LowRankUpdateSymMatrix::ComputeRowA1Impl(
+   Vector& /*rows_norms*/,
+   bool    /*init*/
+) const
+{
+   THROW_EXCEPTION(UNIMPLEMENTED_LINALG_METHOD_CALLED, "LowRankUpdateSymMatrix::ComputeRowA1Impl not implemented");
+}
+
+void LowRankUpdateSymMatrix::ComputeColA1Impl(
+   Vector& /*cols_norms*/,
+   bool    /*init*/
+) const
+{
+   THROW_EXCEPTION(UNIMPLEMENTED_LINALG_METHOD_CALLED, "LowRankUpdateSymMatrix::ComputeColA1Impl not implemented");
+}
+
 void LowRankUpdateSymMatrix::PrintImpl(
    const Journalist&  jnlst,
    EJournalLevel      level,

--- a/src/LinAlg/IpLowRankUpdateSymMatrix.hpp
+++ b/src/LinAlg/IpLowRankUpdateSymMatrix.hpp
@@ -122,7 +122,17 @@ protected:
       bool    init
    ) const;
 
-   virtual void PrintImpl(
+   virtual void ComputeRowA1Impl(
+      Vector& rows_norms,
+      bool    init
+   ) const;
+
+   virtual void ComputeColA1Impl(
+      Vector& cols_norms,
+      bool    init
+  ) const;
+
+  virtual void PrintImpl(
       const Journalist&  jnlst,
       EJournalLevel      level,
       EJournalCategory   category,

--- a/src/LinAlg/IpMatrix.hpp
+++ b/src/LinAlg/IpMatrix.hpp
@@ -163,6 +163,44 @@ public:
    }
    ///@}
 
+   /** Compute the 1-norm of the rows in the matrix.
+    *
+    *  The result is stored in rows_norms.
+    *  The vector is assumed to be initialized if init is false.
+    */
+   void ComputeRowA1(
+      Vector& rows_norms,
+      bool    init = true
+   ) const
+   {
+      DBG_ASSERT(NRows() == rows_norms.Dim());
+      if( init )
+      {
+         rows_norms.Set(0.);
+      }
+      ComputeRowA1Impl(rows_norms, init);
+   }
+   ///@}
+
+   /** Compute the 1-norm of the columns in the matrix.
+    *
+    *  The result is stored in cols_norms.
+    *  The vector is assumed to be initialized if init is false.
+    */
+   void ComputeColA1(
+      Vector& cols_norms,
+      bool    init = true
+   ) const
+   {
+      DBG_ASSERT(NCols() == cols_norms.Dim());
+      if( init )
+      {
+         cols_norms.Set(0.);
+      }
+      ComputeColA1Impl(cols_norms, init);
+   }
+   ///@}
+
    /** Print detailed information about the matrix.
     *
     * @attention Do not overload. Overload PrintImpl instead.
@@ -266,6 +304,24 @@ protected:
     *  The result is stored in cols_norms.
     *  The vector is assumed to be initialized if init is false. */
    virtual void ComputeColAMaxImpl(
+      Vector& cols_norms,
+      bool    init
+   ) const = 0;
+
+   /** Compute the 1-norm of the rows in the matrix.
+    *
+    *  The result is stored in rows_norms.
+    *  The vector is assumed to be initialized if init is false. */
+   virtual void ComputeRowA1Impl(
+      Vector& rows_norms,
+      bool    init
+   ) const = 0;
+
+   /** Compute the 1-norm of the cols in the matrix.
+    *
+    *  The result is stored in cols_norms.
+    *  The vector is assumed to be initialized if init is false. */
+   virtual void ComputeColA1Impl(
       Vector& cols_norms,
       bool    init
    ) const = 0;

--- a/src/LinAlg/IpMultiVectorMatrix.cpp
+++ b/src/LinAlg/IpMultiVectorMatrix.cpp
@@ -301,6 +301,22 @@ void MultiVectorMatrix::ComputeColAMaxImpl(
    THROW_EXCEPTION(UNIMPLEMENTED_LINALG_METHOD_CALLED, "MultiVectorMatrix::ComputeColAMaxImpl not implemented");
 }
 
+void MultiVectorMatrix::ComputeRowA1Impl(
+   Vector& /*rows_norms*/,
+   bool    /*init*/
+) const
+{
+   THROW_EXCEPTION(UNIMPLEMENTED_LINALG_METHOD_CALLED, "MultiVectorMatrix::ComputeRowA1Impl not implemented");
+}
+
+void MultiVectorMatrix::ComputeColA1Impl(
+   Vector& /*cols_norms*/,
+   bool    /*init*/
+) const
+{
+   THROW_EXCEPTION(UNIMPLEMENTED_LINALG_METHOD_CALLED, "MultiVectorMatrix::ComputeColA1Impl not implemented");
+}
+
 void MultiVectorMatrix::PrintImpl(
    const Journalist&  jnlst,
    EJournalLevel      level,

--- a/src/LinAlg/IpMultiVectorMatrix.hpp
+++ b/src/LinAlg/IpMultiVectorMatrix.hpp
@@ -165,6 +165,16 @@ protected:
       bool    init
    ) const;
 
+   virtual void ComputeRowA1Impl(
+      Vector& rows_norms,
+      bool    init
+   ) const;
+
+   virtual void ComputeColA1Impl(
+      Vector& cols_norms,
+      bool    init
+   ) const;
+
    virtual void PrintImpl(
       const Journalist&  jnlst,
       EJournalLevel      level,

--- a/src/LinAlg/IpScaledMatrix.hpp
+++ b/src/LinAlg/IpScaledMatrix.hpp
@@ -89,6 +89,16 @@ protected:
       bool    init
    ) const;
 
+   virtual void ComputeRowA1Impl(
+      Vector& rows_norms,
+      bool    init
+   ) const;
+
+   virtual void ComputeColA1Impl(
+      Vector& cols_norms,
+      bool    init
+   ) const;
+
    virtual void PrintImpl(
       const Journalist&  jnlst,
       EJournalLevel      level,

--- a/src/LinAlg/IpSumMatrix.cpp
+++ b/src/LinAlg/IpSumMatrix.cpp
@@ -136,6 +136,22 @@ void SumMatrix::ComputeColAMaxImpl(
    THROW_EXCEPTION(UNIMPLEMENTED_LINALG_METHOD_CALLED, "SumMatrix::ComputeColAMaxImpl not implemented");
 }
 
+void SumMatrix::ComputeRowA1Impl(
+   Vector& /*rows_norms*/,
+   bool    /*init*/
+) const
+{
+   THROW_EXCEPTION(UNIMPLEMENTED_LINALG_METHOD_CALLED, "SumMatrix::ComputeRowA1Impl not implemented");
+}
+
+void SumMatrix::ComputeColA1Impl(
+   Vector& /*cols_norms*/,
+   bool    /*init*/
+) const
+{
+   THROW_EXCEPTION(UNIMPLEMENTED_LINALG_METHOD_CALLED, "SumMatrix::ComputeColA1Impl not implemented");
+}
+
 void SumMatrix::PrintImpl(
    const Journalist&  jnlst,
    EJournalLevel      level,

--- a/src/LinAlg/IpSumMatrix.hpp
+++ b/src/LinAlg/IpSumMatrix.hpp
@@ -83,6 +83,16 @@ protected:
       bool    init
    ) const;
 
+   virtual void ComputeRowA1Impl(
+      Vector& rows_norms,
+      bool    init
+   ) const;
+
+   virtual void ComputeColA1Impl(
+      Vector& cols_norms,
+      bool    init
+   ) const;
+
    virtual void PrintImpl(
       const Journalist&  jnlst,
       EJournalLevel      level,

--- a/src/LinAlg/IpSumSymMatrix.cpp
+++ b/src/LinAlg/IpSumSymMatrix.cpp
@@ -108,6 +108,30 @@ void SumSymMatrix::ComputeColAMaxImpl(
    THROW_EXCEPTION(UNIMPLEMENTED_LINALG_METHOD_CALLED, "SumSymMatrix::ComputeColAMaxImpl not implemented");
 }
 
+void SumSymMatrix::ComputeRowA1Impl(
+   Vector& rows_norms,
+   bool    /*init*/
+) const
+{
+   for( Index iterm = 0; iterm < NTerms(); iterm++ )
+   {
+      DBG_ASSERT(IsValid(matrices_[iterm]));
+      matrices_[iterm]->ComputeRowA1(rows_norms, false);
+   }
+}
+
+void SumSymMatrix::ComputeColA1Impl(
+   Vector& cols_norms,
+   bool    /*init*/
+) const
+{
+   for( Index iterm = 0; iterm < NTerms(); iterm++ )
+   {
+      DBG_ASSERT(IsValid(matrices_[iterm]));
+      matrices_[iterm]->ComputeColA1(cols_norms, false);
+   }
+}
+
 void SumSymMatrix::PrintImpl(
    const Journalist&  jnlst,
    EJournalLevel      level,

--- a/src/LinAlg/IpSumSymMatrix.hpp
+++ b/src/LinAlg/IpSumSymMatrix.hpp
@@ -81,6 +81,16 @@ protected:
       bool    init
    ) const;
 
+   virtual void ComputeRowA1Impl(
+      Vector& rows_norms,
+      bool    init
+   ) const;
+
+   virtual void ComputeColA1Impl(
+      Vector& cols_norms,
+      bool    init
+   ) const;
+
    virtual void PrintImpl(
       const Journalist&  jnlst,
       EJournalLevel      level,

--- a/src/LinAlg/IpSymMatrix.hpp
+++ b/src/LinAlg/IpSymMatrix.hpp
@@ -74,6 +74,19 @@ protected:
    }
    ///@}
 
+    /** Implementation of ComputeColA1Impl, which calls ComputeRowA1Impl.
+    *
+    * Since the matrix is symmetric, the row and column 1 norms are identical.
+    */
+   virtual void ComputeColA1Impl(
+      Vector& cols_norms,
+      bool    init
+   ) const
+   {
+      ComputeRowA1Impl(cols_norms, init);
+   }
+   ///@}
+
 private:
    /** Copy of the owner space ptr as a SymMatrixSpace instead
     *  of a MatrixSpace

--- a/src/LinAlg/IpSymScaledMatrix.cpp
+++ b/src/LinAlg/IpSymScaledMatrix.cpp
@@ -70,6 +70,14 @@ void SymScaledMatrix::ComputeRowAMaxImpl(
    THROW_EXCEPTION(UNIMPLEMENTED_LINALG_METHOD_CALLED, "SymScaledMatrix::ComputeRowAMaxImpl not implemented");
 }
 
+void SymScaledMatrix::ComputeRowA1Impl(
+   Vector& /*rows_norms*/,
+   bool    /*init*/
+) const
+{
+   THROW_EXCEPTION(UNIMPLEMENTED_LINALG_METHOD_CALLED, "SymScaledMatrix::ComputeRowA1Impl not implemented");
+}
+
 void SymScaledMatrix::PrintImpl(
    const Journalist&  jnlst,
    EJournalLevel      level,

--- a/src/LinAlg/IpSymScaledMatrix.hpp
+++ b/src/LinAlg/IpSymScaledMatrix.hpp
@@ -74,6 +74,11 @@ protected:
       bool    init
    ) const;
 
+   virtual void ComputeRowA1Impl(
+      Vector& rows_norms,
+      bool    init
+   ) const;
+
    virtual void PrintImpl(
       const Journalist&  jnlst,
       EJournalLevel      level,

--- a/src/LinAlg/IpTransposeMatrix.hpp
+++ b/src/LinAlg/IpTransposeMatrix.hpp
@@ -85,6 +85,22 @@ protected:
       orig_matrix_->ComputeRowAMax(rows_norms, init);
    }
 
+   virtual void ComputeRowA1Impl(
+      Vector& rows_norms,
+      bool    init
+   ) const {
+      DBG_ASSERT(IsValid(orig_matrix_));
+      orig_matrix_->ComputeColA1(rows_norms, init);
+   }
+
+   virtual void ComputeColA1Impl(
+      Vector& cols_norms,
+      bool    init
+   ) const {
+      DBG_ASSERT(IsValid(orig_matrix_));
+      orig_matrix_->ComputeRowA1(cols_norms, init);
+   }
+
    virtual void PrintImpl(
       const Journalist&  jnlst,
       EJournalLevel      level,

--- a/src/LinAlg/IpZeroMatrix.hpp
+++ b/src/LinAlg/IpZeroMatrix.hpp
@@ -58,6 +58,18 @@ protected:
    ) const
    { }
 
+   virtual void ComputeRowA1Impl(
+      Vector& /*rows_norms*/,
+      bool    /*init*/
+   ) const
+   { }
+
+   virtual void ComputeColA1Impl(
+      Vector& /*cols_norms*/,
+      bool    /*init*/
+   ) const
+   { }
+
    virtual void PrintImpl(
       const Journalist&  jnlst,
       EJournalLevel      level,

--- a/src/LinAlg/IpZeroSymMatrix.hpp
+++ b/src/LinAlg/IpZeroSymMatrix.hpp
@@ -57,6 +57,18 @@ protected:
    ) const
    { }
 
+   virtual void ComputeRowA1Impl(
+      Vector& /*rows_norms*/,
+      bool    /*init*/
+   ) const
+   { }
+
+   virtual void ComputeColA1Impl(
+      Vector& /*cols_norms*/,
+      bool    /*init*/
+   ) const
+   { }
+
    virtual void PrintImpl(
       const Journalist&  jnlst,
       EJournalLevel      level,

--- a/src/LinAlg/TMatrices/IpGenTMatrix.cpp
+++ b/src/LinAlg/TMatrices/IpGenTMatrix.cpp
@@ -238,6 +238,60 @@ void GenTMatrix::ComputeColAMaxImpl(
    }
 }
 
+void GenTMatrix::ComputeRowA1Impl(
+   Vector& rows_norms,
+   bool    /*init*/
+) const
+{
+   DBG_ASSERT(initialized_);
+
+   if( NRows() == 0 )
+   {
+      return;
+   }
+
+   DenseVector* dense_vec = static_cast<DenseVector*>(&rows_norms);
+   DBG_ASSERT(dynamic_cast<DenseVector*>(&rows_norms));
+
+   const Index* irows = Irows();
+   const Number* val = values_;
+   Number* vec_vals = dense_vec->Values();
+   DBG_ASSERT(vec_vals != NULL);
+
+   vec_vals--;
+   for( Index i = 0; i < Nonzeros(); i++ )
+   {
+      vec_vals[irows[i]] += std::abs(val[i]);
+   }
+}
+
+void GenTMatrix::ComputeColA1Impl(
+   Vector& cols_norms,
+   bool    /*init*/
+) const
+{
+   DBG_ASSERT(initialized_);
+
+   if( NCols() == 0 )
+   {
+      return;
+   }
+
+   DenseVector* dense_vec = static_cast<DenseVector*>(&cols_norms);
+   DBG_ASSERT(dynamic_cast<DenseVector*>(&cols_norms));
+
+   const Index* jcols = Jcols();
+   const Number* val = values_;
+   Number* vec_vals = dense_vec->Values();
+   DBG_ASSERT(vec_vals != NULL);
+
+   vec_vals--; // to deal with 1-based indexing in jcols, I believe
+   for( Index i = 0; i < Nonzeros(); i++ )
+   {
+      vec_vals[jcols[i]] += std::abs(val[i]);
+   }
+}
+
 void GenTMatrix::PrintImplOffset(
    const Journalist&  jnlst,
    EJournalLevel      level,

--- a/src/LinAlg/TMatrices/IpGenTMatrix.hpp
+++ b/src/LinAlg/TMatrices/IpGenTMatrix.hpp
@@ -119,6 +119,16 @@ protected:
       bool    init
    ) const;
 
+   virtual void ComputeRowA1Impl(
+      Vector& rows_norms,
+      bool    init
+   ) const;
+
+   virtual void ComputeColA1Impl(
+      Vector& cols_norms,
+      bool    init
+   ) const;
+
    virtual void PrintImpl(
       const Journalist&  jnlst,
       EJournalLevel      level,

--- a/src/LinAlg/TMatrices/IpSymTMatrix.cpp
+++ b/src/LinAlg/TMatrices/IpSymTMatrix.cpp
@@ -197,6 +197,42 @@ void SymTMatrix::ComputeRowAMaxImpl(
    }
 }
 
+void SymTMatrix::ComputeRowA1Impl(
+   Vector& rows_norms,
+   bool    /*init*/
+) const
+{
+   DBG_ASSERT(initialized_);
+
+   if( NRows() == 0 )
+   {
+      return;
+   }
+
+   DenseVector* dense_vec = static_cast<DenseVector*>(&rows_norms);
+   DBG_ASSERT(dynamic_cast<DenseVector*>(&rows_norms));
+
+   const Index* irn = Irows();
+   const Index* jcn = Jcols();
+   const Number* val = values_;
+   Number* vec_vals = dense_vec->Values();
+   DBG_ASSERT(vec_vals != NULL);
+
+   // const Number zero = 0.;
+   // IpBlasCopy(NRows(), &zero, 0, vec_vals, 1);
+
+   vec_vals--; // to deal with 1-based indexing in irn and jcn (I believe)
+   for( Index i = 0; i < Nonzeros(); i++ )
+   {
+      const Number f = std::abs(*val);
+      vec_vals[*irn] += f;
+      vec_vals[*jcn] += f;
+      val++;
+      irn++;
+      jcn++;
+   }
+}
+
 void SymTMatrix::PrintImpl(
    const Journalist&  jnlst,
    EJournalLevel      level,

--- a/src/LinAlg/TMatrices/IpSymTMatrix.hpp
+++ b/src/LinAlg/TMatrices/IpSymTMatrix.hpp
@@ -129,6 +129,11 @@ protected:
       bool    init
    ) const;
 
+   virtual void ComputeRowA1Impl(
+      Vector& rows_norms,
+      bool    init
+   ) const;
+
    virtual void PrintImpl(
       const Journalist&  jnlst,
       EJournalLevel      level,


### PR DESCRIPTION
This PR implements the flexible generalized minimal residual method for refinement of the solution of the primal-dual system.
The main changes/additions in this PR are:

- The FGMRES solver, a preconditioned Krylov method. FGMRES should be more robust than the current iterative refinement.  The flexible version is also more robust than the regular restarted version of GMRES, see for instance https://doi.org/10.1137/060661545.
- An option to enable/disable this FGMRES refinement. In the PR FGMRES is enabled by default. If FGMRES is disabled, iterative refinement is used as before.
- The `ComputeResidualRatio` method is modified to now compute the Infinity norm-wise relative backward error, which is used in the stopping criterion for FGMRES and iterative refinement.
- New routine `PDFullSpaceSolver::NrmInf` to compute the Inf-norm of the primal-dual system, which is used to compute the relative backward error.
- Added routines `ComputeRowA1` and `ComputeColA1` in `IpMatrix` to compute the 1-norm of the rows/columns in the matrix. This is implemented in the derived classes.
- Modified `PDFullSpaceSolver::ComputeResiduals` to use the `alpha` and `beta` parameters so it can be used to compute a matrix vector product (or the residual).

Our tests show improvements in convergence when using FGMRES compared to iterative refinement, for select problems, with minimal runtime overhead.

@bknueven @k1nshuk