### PR TITLE
Add MPI communicator option to the MUMPS solver interface

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -15,6 +15,8 @@ More detailed information about incremental changes can be found in the
   to enable check for interrupt signal in `intermediate_callback`.
 - The `ipopt` and `ipopt_sens` executables can now be interrupted by SIGINT/SIGHUP
   (POSIX systems) or SIGINT/SIGTERM/SIGABRT (Windows systems).
+- New option `mumps_mpi_communicator` to specify the MPI communicator when using
+  an MPI-enabled build of MUMPS [#790, by Alex Tyler Chapman].
 
 ### 3.14.16 (2024-04-22)
 

--- a/doc/options.dox
+++ b/doc/options.dox
@@ -2473,6 +2473,12 @@ Possible values:
  This is CNTL(3) in MUMPS. The valid range for this real option is unrestricted and its default value is 0.
 </blockquote>
 
+\anchor OPT_mumps_mpi_communicator
+<strong>mumps_mpi_communicator</strong> (<em>advanced</em>): MPI communicator used for matrix operations
+<blockquote>
+ This sets the MPI communicator. MPI_COMM_WORLD is the default. Any other value should be the return value from MPI_Comm_c2f. The valid range for this integer option is unrestricted and its default value is -987654.
+</blockquote>
+
 
 \subsection OPT_MA28_Linear_Solver MA28 Linear Solver
 

--- a/src/Algorithm/LinearSolvers/IpMumpsSolverInterface.cpp
+++ b/src/Algorithm/LinearSolvers/IpMumpsSolverInterface.cpp
@@ -182,7 +182,7 @@ void MumpsSolverInterface::RegisterOptions(
       "mumps_mpi_communicator",
       "MPI communicator used for matrix operations",
       USE_COMM_WORLD,
-      "This sets the MPI communicator. MPI_COMM_WORLD is the default. Any other value should be the return value from MPI_Comm_c2f");
+      "This sets the MPI communicator. MPI_COMM_WORLD is the default. Any other value should be the return value from MPI_Comm_c2f", true);
 }
 
 /// give name of MUMPS with version info

--- a/src/Algorithm/LinearSolvers/IpMumpsSolverInterface.cpp
+++ b/src/Algorithm/LinearSolvers/IpMumpsSolverInterface.cpp
@@ -97,13 +97,11 @@ MumpsSolverInterface::MumpsSolverInterface()
    mumps_->job = -1; //initialize mumps
    mumps_->par = 1; //working host for sequential version
    mumps_->sym = 2; //general symmetric matrix
-   mumps_->comm_fortran = USE_COMM_WORLD;
 
 #ifndef IPOPT_MUMPS_NOMUTEX
    const std::lock_guard<std::mutex> lock(mumps_call_mutex);
 #endif
 
-   mumps_c(mumps_);
    mumps_->icntl[2] = 0;  // global info stream
    mumps_->icntl[3] = 0;  // print level
    mumps_ptr_ = (void*) mumps_;
@@ -180,6 +178,11 @@ void MumpsSolverInterface::RegisterOptions(
       "Threshold to consider a pivot at zero in detection of linearly dependent constraints with MUMPS.",
       0.0,
       "This is CNTL(3) in MUMPS.", true);
+   roptions->AddIntegerOption(
+      "mumps_mpi_communicator",
+      "MPI communicator used for matrix operations",
+      USE_COMM_WORLD,
+      "This sets the MPI communicator. MPI_COMM_WORLD is the default. Any other value should be the return value from MPI_Comm_c2f");
 }
 
 /// give name of MUMPS with version info
@@ -217,13 +220,24 @@ bool MumpsSolverInterface::InitializeImpl(
    options.GetIntegerValue("mumps_scaling", mumps_scaling_, prefix);
    options.GetNumericValue("mumps_dep_tol", mumps_dep_tol_, prefix);
 
+   MUMPS_STRUC_C* mumps_ = static_cast<MUMPS_STRUC_C*>(mumps_ptr_);
+
+#ifndef IPOPT_MUMPS_NOMUTEX
+   const std::lock_guard<std::mutex> lock(mumps_call_mutex);
+#endif
+
+   Index mpi_comm;
+   options.GetIntegerValue("mumps_mpi_communicator", mpi_comm, prefix);
+   mumps_->comm_fortran = static_cast<int>(mpi_comm);
+
+   mumps_c(mumps_);
+
    // Reset all private data
    initialized_ = false;
    pivtol_changed_ = false;
    refactorize_ = false;
    have_symbolic_factorization_ = false;
 
-   MUMPS_STRUC_C* mumps_ = static_cast<MUMPS_STRUC_C*>(mumps_ptr_);
    if( !warm_start_same_structure_ )
    {
       mumps_->n = 0;

--- a/src/Algorithm/LinearSolvers/IpMumpsSolverInterface.cpp
+++ b/src/Algorithm/LinearSolvers/IpMumpsSolverInterface.cpp
@@ -176,7 +176,7 @@ void MumpsSolverInterface::RegisterOptions(
       "mumps_mpi_communicator",
       "MPI communicator used for matrix operations",
       USE_COMM_WORLD,
-      "This sets the MPI communicator. MPI_COMM_WORLD is the default. Any other value should be the return value from MPI_Comm_c2f", true);
+      "This sets the MPI communicator. MPI_COMM_WORLD is the default. Any other value should be the return value from MPI_Comm_c2f.", true);
 }
 
 /// give name of MUMPS with version info


### PR DESCRIPTION
This PR adds an MPI communicator option to the MUMPS solver interface. The motivation for this came from wanting to use MUMPS with `MPI_COMM_SELF`.

The project that I'm working on, internal to LLNL, runs in parallel, but runs MUMPS serially. In order to achieve this, we configure MUMPS with MPI, but set `--disable-mpiinit` as described [here](https://coin-or.github.io/Ipopt/INSTALL.html) under "MUMPS Linear Solver".

We use Spack to install our third party libraries, including Ipopt and MUMPS. This means we are not using the recommended ThirdParty-Mumps. Figured I would share for awareness (our package.py is slightly different): https://github.com/spack/spack/blob/develop/var/spack/repos/builtin/packages/ipopt/package.py.

Before the changes in this PR, our tests were hanging when run with multiple MPI tasks.