### PR TITLE
AmplTNLP: Use _strdup if _WIN32 is defined

### DIFF
--- a/src/Apps/AmplSolver/AmplTNLP.cpp
+++ b/src/Apps/AmplSolver/AmplTNLP.cpp
@@ -14,6 +14,13 @@
 
 #include <cstring>
 
+// strdup is named _strdup on Windows
+#ifdef _WIN32
+#define ipopt_strdup _strdup
+#else
+#define ipopt_strdup strdup
+#endif
+
 /* AMPL includes */
 #include "asl.h"
 #include "asl_pfgh.h"
@@ -1807,7 +1814,7 @@ void AmplSuffixHandler::PrepareAmplForSuffixes(
    suftab_ = new SufDecl[n];
    for( Index i = 0; i < n; i++ )
    {
-      suftab_[i].name = strdup(suffix_ids_[i].c_str());
+      suftab_[i].name = ipopt_strdup(suffix_ids_[i].c_str());
       suftab_[i].table = 0;
 
       if( suffix_sources_[i] == Variable_Source )


### PR DESCRIPTION
Context for the change: in the conda-forge package of ipopt in https://github.com/conda-forge/ipopt-feedstock/pull/123 we tried to get rid of the custom vendored CMake scripts used to build the package in Windows, to use the autotools-based build system on Windows as well (using MSVC-compatible llvm compilers), and to easily link with ampl-asl. This worked fine, but we had linking problems with `strdup`, as indeed `strdup` is not available on Windows and the equivalent Windows function is called `_strdup`. 

This PR fixes (for our setup) the problem by using `_strdup` on Windows while using `strdup` on Linux/macOS, but I am not sure if this creates regression on the Windows compilation with Intel compilers that apparently was working fine with `strdup`.