### PR TITLE
Update the links for libHSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ in the Ipopt documentation. In the following, we only summarize some main points
 Ipopt requires at least one of the following solvers for systems of linear equations:
 - MA27, MA57, HSL_MA77, HSL_MA86, or HSL_MA97 from the [Harwell Subroutines Library](http://hsl.rl.ac.uk) (HSL).
   It is recommended to use project [ThirdParty-HSL](https://github.com/coin-or-tools/ThirdParty-HSL) to build a HSL library for use by Ipopt
-  or to use [prebuild macOS/Windows libraries from STFC](https://licences.stfc.ac.uk/product/libhsl), see the [Ipopt installation instruction](https://coin-or.github.io/Ipopt/INSTALL.html#DOWNLOAD_HSL).
+  or to use [prebuild macOS/Windows/Linux libraries from STFC](https://licences.stfc.ac.uk/products/Software/HSL/LibHSL), see the [Ipopt installation instruction](https://coin-or.github.io/Ipopt/INSTALL.html#DOWNLOAD_HSL).
 - [Parallel Sparse Direct Linear Solver](http://www.pardiso-project.org) (Pardiso).
   Note, that the Intel Math Kernel Library (MKL) also includes a version of Pardiso, but the one from Pardiso Project often offers better performance.
 - [Sparse Parallel Robust Algorithms Library](https://github.com/ralna/spral) (SPRAL).
@@ -111,7 +111,7 @@ More details on using coinbrew can be found at the instructions on
 Some precompiled binaries of Ipopt are also available:
 
 - **[Ipopt releases page](https://github.com/coin-or/Ipopt/releases)** provides libraries and executables for Windows
-- **[JuliaBinaryWrappers](https://github.com/JuliaBinaryWrappers/Ipopt_jll.jl/releases)** provides libraries and executables; [JuliaHSL](https://licences.stfc.ac.uk/product/julia-hsl) provides prebuild HSL libraries
+- **[JuliaBinaryWrappers](https://github.com/JuliaBinaryWrappers/Ipopt_jll.jl/releases)** provides libraries and executables; [libHSL](https://licences.stfc.ac.uk/products/Software/HSL/LibHSL) provides prebuild HSL libraries
 - **[IDEAS](https://github.com/IDAES/idaes-ext/releases)** provides executables; these executables include HSL solvers
 
 Getting Help

--- a/doc/install.dox
+++ b/doc/install.dox
@@ -231,8 +231,8 @@ You may either:
 of a HSL library, if a HSL library is provided.
 
 Next to the HSL source packages, also **prebuild libraries** of HSL for macOS and Windows are
-available in the libHSL package from https://licences.stfc.ac.uk/product/libhsl
-and the Coin-HSL package from https://licences.stfc.ac.uk/product/coin-hsl.
+available in the libHSL package from https://licences.stfc.ac.uk/products/Software/HSL/LibHSL
+and the Coin-HSL package from https://licences.stfc.ac.uk/products/Software/HSL/coinhsl.
 Both can be used by %Ipopt when using the shared library loading mechanism
 described \ref LINEARSOLVERLOADER "below".
 
@@ -255,7 +255,7 @@ codes, you can specify the directory containing the `CoinHslConfig.h`
 header file and the linker flags for this library with the
 flags `--with-hsl-cflags` and `--with-hsl-lflags` flags, respectively,
 when running `configure` of %Ipopt  (see \ref COMPILEINSTALL).
-The JuliaHSL libs can not be used with `--with-hsl-lflags`, as they do
+The libHSL libs can not be used with `--with-hsl-lflags`, as they do
 not contain the necessary header files.
 
 \note The linear solvers MA57, HSL_MA77, HSL_MA86, HSL_MA97 can
@@ -278,7 +278,7 @@ which to load HSL routines if a HSL solver is selected. The name can contain
 a path; otherwise, the shared library search path (e.g., `LD_LIBRARY_PATH`)
 will be used.
 
-Prebuild HSL libraries are available from https://licences.stfc.ac.uk/product/julia-hsl (see also above).
+Prebuild HSL libraries are available from https://licences.stfc.ac.uk/products/Software/HSL/LibHSL (see also above).
 
 \subsection DOWNLOAD_MUMPS MUMPS Linear Solver
 


### PR DESCRIPTION
We released a new version of libHSL (`2024.11.28`).
We also provide precompiled linuw binaries now.