### PR TITLE
add API functions to retrieve Ipopt version from library

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -14,6 +14,8 @@ More detailed information about incremental changes can be found in the
 - Fixed that Jipopt::finalize_solution did not store final objective value correctly
   [#820, by Kevin Kofler]. Instead, the value of the last iterate evaluation was returned,
   which was often the same.
+- Added IpoptApplication::Version() (C++ interface) and GetIpoptVersion (C interface) to
+  retrieve version of Ipopt library [#824].
 
 ### 3.14.17 (2024-12-14)
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -14,8 +14,8 @@ More detailed information about incremental changes can be found in the
 - Fixed that Jipopt::finalize_solution did not store final objective value correctly
   [#820, by Kevin Kofler]. Instead, the value of the last iterate evaluation was returned,
   which was often the same.
-- Added IpoptApplication::Version() (C++ interface) and GetIpoptVersion (C interface) to
-  retrieve version of Ipopt library [#824].
+- Added IpoptApplication::Version() (C++ interface), GetIpoptVersion (C interface), and
+  Ipopt::GetVersion() (Java interface) to retrieve version of Ipopt library [#824].
 
 ### 3.14.17 (2024-12-14)
 

--- a/examples/hs071_java/HS071.java
+++ b/examples/hs071_java/HS071.java
@@ -395,6 +395,11 @@ public class HS071 extends Ipopt
       // Create the problem
       HS071 hs071 = new HS071();
 
+      // Get and print the Ipopt version
+      int version[] = new int[3];
+      hs071.getVersion(version);
+      System.out.println("Ipopt version: " + version[0] + "." + version[1] + "." + version[2]);
+
       // Set some options
       // hs071.setNumericOption("tol",1E-7);
       // hs071.setStringOption("nlp_scaling_method","user-scaling");

--- a/src/Interfaces/IpIpoptApplication.cpp
+++ b/src/Interfaces/IpIpoptApplication.cpp
@@ -1047,4 +1047,15 @@ void IpoptApplication::PrintCopyrightMessage()
    IpoptAlgorithm::print_copyright_message(*jnlst_);
 }
 
+void IpoptApplication::Version(
+   int& major,
+   int& minor,
+   int& release
+)
+{
+   major = IPOPT_VERSION_MAJOR;
+   minor = IPOPT_VERSION_MINOR;
+   release = IPOPT_VERSION_RELEASE;
+}
+
 } // namespace Ipopt

--- a/src/Interfaces/IpIpoptApplication.hpp
+++ b/src/Interfaces/IpIpoptApplication.hpp
@@ -265,9 +265,21 @@ public:
    );
 
    /** Method to register all Ipopt options. */
-   static void
-   RegisterAllIpoptOptions(
+   static void RegisterAllIpoptOptions(
       const SmartPtr<RegisteredOptions>& roptions
+   );
+
+   /** Return version of Ipopt library.
+    *
+    * Gives the value of IPOPT_VERSION_MAJOR, IPOPT_VERSION_MINOR, and IPOPT_VERSION_RELEASE
+    * that were used when the Ipopt library was build.
+    *
+    * @since 3.14.18
+    */
+   static void Version(
+      int& major,   /**< set to major version number of Ipopt */
+      int& minor,   /**< set to minor version number of Ipopt */
+      int& release  /**< set to release version number of Ipopt */
    );
 
 private:

--- a/src/Interfaces/IpStdCInterface.cpp
+++ b/src/Interfaces/IpStdCInterface.cpp
@@ -11,6 +11,8 @@
 #include "IpBlas.hpp"
 #include "IpSmartPtr.hpp"
 
+#include <cassert>
+
 struct IpoptProblemInfo
 {
    Ipopt::SmartPtr<Ipopt::IpoptApplication> app;
@@ -330,4 +332,17 @@ bool GetIpoptCurrentViolations(
    }
 
    return ipopt_problem->tnlp->get_curr_violations(scaled != 0, n, x_L_violation, x_U_violation, compl_x_L, compl_x_U, grad_lag_x, m, nlp_constraint_violation, compl_g);
+}
+
+void GetIpoptVersion(
+   int* major,   /**< buffer to store major version number of Ipopt */
+   int* minor,   /**< buffer to store minor version number of Ipopt */
+   int* release  /**< buffer to store release version number of Ipopt */
+)
+{
+   assert(major != NULL);
+   assert(minor != NULL);
+   assert(release != NULL);
+
+   Ipopt::IpoptApplication::Version(*major, *minor, *release);
 }

--- a/src/Interfaces/IpStdCInterface.h
+++ b/src/Interfaces/IpStdCInterface.h
@@ -421,6 +421,19 @@ IPOPTLIB_EXPORT bool IPOPT_CALLCONV GetIpoptCurrentViolations(
    ipnumber*     compl_g
 );
 
+/** Return version of Ipopt library.
+ *
+ * Gives the value of IPOPT_VERSION_MAJOR, IPOPT_VERSION_MINOR, and IPOPT_VERSION_RELEASE
+ * that were used when the Ipopt library was build.
+ *
+ * @since 3.14.18
+ */
+IPOPTLIB_EXPORT void IPOPT_CALLCONV GetIpoptVersion(
+   int* major,   /**< buffer to store major version number of Ipopt */
+   int* minor,   /**< buffer to store minor version number of Ipopt */
+   int* release  /**< buffer to store release version number of Ipopt */
+);
+
 #ifdef __cplusplus
 } /* extern "C" { */
 #endif

--- a/src/Interfaces/IpStdJInterface.cpp
+++ b/src/Interfaces/IpStdJInterface.cpp
@@ -1143,4 +1143,20 @@ extern "C"
       return ret;
    }
 
+   JNIEXPORT void JNICALL Java_org_coinor_Ipopt_GetVersion(
+      JNIEnv*   env,
+      jobject /*obj_this*/,
+      jintArray jversion
+   )
+   {
+      int version[3];
+      IpoptApplication::Version(version[0], version[1], version[2]);
+
+      /* int[] -> jint[] */
+      jint versionj[3] = { version[0], version[1], version[2] };
+
+      /* jint[] -> jintArray */
+      env->SetIntArrayRegion(jversion, 0, 3, versionj);
+   }
+
 } // extern "C"

--- a/src/Interfaces/Ipopt.java
+++ b/src/Interfaces/Ipopt.java
@@ -124,6 +124,11 @@ public abstract class Ipopt
       double   compl_g[]
    );
 
+   /* Native function should not be used directly */
+   private native void GetVersion(
+      int version[]
+   );
+
    /** Use C index style for iRow and jCol vectors */
    public final static int C_STYLE = 0;
 
@@ -850,5 +855,20 @@ public abstract class Ipopt
       int[] pos_nonlin_vars)
    {
       return false;
+   }
+
+   /** Get version of Ipopt library.
+    *
+    * Gives the value of IPOPT_VERSION_MAJOR, IPOPT_VERSION_MINOR, and IPOPT_VERSION_RELEASE
+    * that were used when the Ipopt library was build.
+    *
+    * @param version int[3] to store major, minor, and release version number
+    * @since 3.14.18
+    */
+   public void getVersion(
+      int[] version
+   )
+   {
+      GetVersion(version);
    }
 }


### PR DESCRIPTION
Adds functions to C++, C, and Java interface to get major, minor, and release part of Ipopt version.

@amontoison would that work for you?

CC @kkofler

Closes #824.