### PR TITLE
Correct ipyopt link and spelling

### DIFF
--- a/doc/main.dox
+++ b/doc/main.dox
@@ -280,7 +280,7 @@ maintained by other people, among them are:
 
     Modern, light-weight (~1k loc), **Eigen**-based <strong>C++</strong> interface to %Ipopt and Snopt.
 
--   [IPyOpt](https://gitlab.com/g-braeunlich/ipyopt)
+-   [ipyopt](https://gitlab.com/ipyopt-devs/ipyopt)
 
     Interfacing %Ipopt from **Python**.
 


### PR DESCRIPTION
Going to https://gitlab.com/g-braeunlich/ipyopt redirects to the new location with a message:

Project 'g-braeunlich/ipyopt' was moved to 'ipyopt-devs/ipyopt'. Please update any links and bookmarks that may still have the old path.

This updates the link. (And changes capitalization to ipyopt which seems to be the preferred way.)