### PR TITLE
fix several valgrind warnings on using uninitizalied values

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -16,6 +16,8 @@ More detailed information about incremental changes can be found in the
   which was often the same.
 - Added IpoptApplication::Version() (C++ interface), GetIpoptVersion (C interface), and
   Ipopt::GetVersion() (Java interface) to retrieve version of Ipopt library [#824].
+- Fixed possible missing initialization of delta_x and delta_s in PDPerturbationHandler
+  in case ConsiderNewSystem failed [#834].
 
 ### 3.14.17 (2024-12-14)
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -19,6 +19,9 @@ More detailed information about incremental changes can be found in the
 - Fixed possible missing initialization of delta_x and delta_s in PDPerturbationHandler
   in case ConsiderNewSystem failed [#834].
 - Undefine `max` if defined after include of windows.h in IpUtils.cpp [#834].
+- Added missing initialization of Filter Acceptor in case restoration phase is called
+  when the fallback mechanism of BacktrackingLinearSearch has been activated [#834].
+  If this happened in the first iteration, it lead to the use of uninitialized values.
 
 ### 3.14.17 (2024-12-14)
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -18,6 +18,7 @@ More detailed information about incremental changes can be found in the
   Ipopt::GetVersion() (Java interface) to retrieve version of Ipopt library [#824].
 - Fixed possible missing initialization of delta_x and delta_s in PDPerturbationHandler
   in case ConsiderNewSystem failed [#834].
+- Undefine `max` if defined after include of windows.h in IpUtils.cpp [#834].
 
 ### 3.14.17 (2024-12-14)
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -22,6 +22,7 @@ More detailed information about incremental changes can be found in the
 - Added missing initialization of Filter Acceptor in case restoration phase is called
   when the fallback mechanism of BacktrackingLinearSearch has been activated [#834].
   If this happened in the first iteration, it lead to the use of uninitialized values.
+- Added missing return if symbolic factorization with MA57 (ma57ad, ma57as) failed [#834].
 
 ### 3.14.17 (2024-12-14)
 

--- a/src/Algorithm/IpBacktrackingLineSearch.cpp
+++ b/src/Algorithm/IpBacktrackingLineSearch.cpp
@@ -324,10 +324,14 @@ void BacktrackingLineSearch::FindAcceptableTrialPoint()
    }
    else
    {
-      // Initialize the acceptor for this backtracking line search
-      acceptor_->InitThisLineSearch(in_watchdog_);
       actual_delta = IpData().delta()->MakeNewContainer();
    }
+   // Initialize the acceptor for this backtracking line search
+   // this was originally only done if fallback_activated_ was not true, i.e., if we were not going into restoration phase
+   // however, if the fallback is activated, we may go to the restoration phase below, which calls acceptor_->PrepareRestoPhaseStart()
+   // below, which calls FilterLSAcceptor::AugmentFilter(), which needs to have reference_barr_ and reference_theta_ initialized
+   // so we call InitThisLineSearch also in this case now
+   acceptor_->InitThisLineSearch(in_watchdog_);
 
    if( start_with_resto_ )
    {

--- a/src/Algorithm/IpFilterLSAcceptor.cpp
+++ b/src/Algorithm/IpFilterLSAcceptor.cpp
@@ -23,6 +23,7 @@ static const Index dbg_verbosity = 0;
 
 FilterLSAcceptor::FilterLSAcceptor(const SmartPtr<PDSystemSolver>& pd_solver)
    :
+   reference_initialized_(false),
    filter_(2),
    pd_solver_(pd_solver)
 {
@@ -265,6 +266,7 @@ void FilterLSAcceptor::InitThisLineSearch(bool in_watchdog)
       reference_barr_ = watchdog_barr_;
       reference_gradBarrTDelta_ = watchdog_gradBarrTDelta_;
    }
+   reference_initialized_ = true;
    filter_.Print(Jnlst());
 }
 
@@ -296,6 +298,8 @@ void FilterLSAcceptor::AugmentFilter()
 {
    DBG_START_METH("FilterLSAcceptor::AugmentFilter",
                   dbg_verbosity);
+
+   DBG_ASSERT(reference_initialized_);
 
    Number phi_add = reference_barr_ - gamma_phi_ * reference_theta_;
    Number theta_add = (1. - gamma_theta_) * reference_theta_;

--- a/src/Algorithm/IpFilterLSAcceptor.hpp
+++ b/src/Algorithm/IpFilterLSAcceptor.hpp
@@ -290,6 +290,10 @@ private:
     *  respect to which progress is to be made
     */
    Number reference_gradBarrTDelta_;
+   /** Whether reference_theta_, reference_barr_, reference_gradBarrTDelta_
+    *  have been initialized by a call to InitThisLineSearch().
+    */
+   bool reference_initialized_;
    /** Constraint violation at reference point */
    Number watchdog_theta_;
    /** Barrier objective function at reference point */

--- a/src/Algorithm/IpPDPerturbationHandler.cpp
+++ b/src/Algorithm/IpPDPerturbationHandler.cpp
@@ -216,6 +216,9 @@ bool PDPerturbationHandler::ConsiderNewSystem(
    }
    delta_d = delta_d_curr_ = delta_c;
 
+   delta_x = 0.;
+   delta_s = 0.;
+
    if( hess_degenerate_ == DEGENERATE )
    {
       delta_x_curr_ = 0.;
@@ -225,11 +228,6 @@ bool PDPerturbationHandler::ConsiderNewSystem(
       {
          return false;
       }
-   }
-   else
-   {
-      delta_x = 0.;
-      delta_s = delta_x;
    }
 
    delta_x_curr_ = delta_x;

--- a/src/Algorithm/LinearSolvers/IpMa57TSolverInterface.cpp
+++ b/src/Algorithm/LinearSolvers/IpMa57TSolverInterface.cpp
@@ -576,6 +576,7 @@ ESymSolverStatus Ma57TSolverInterface::SymbolicFactorization(
    {
       Jnlst().Printf(J_ERROR, J_LINEAR_ALGEBRA,
                      "*** Error from MA57AD *** INFO(0) = %" IPOPT_INDEX_FORMAT "\n", wd_info_[0]);
+      return SYMSOLVER_FATAL_ERROR;
    }
 
    wd_lfact_ = 0;

--- a/src/Common/IpUtils.cpp
+++ b/src/Common/IpUtils.cpp
@@ -51,6 +51,9 @@
    '#define small char' */
 #undef small
 #endif
+#ifdef max
+#undef max
+#endif
 #define TWO_TO_THE_THIRTYTWO 4294967296.0
 #define DELTA_EPOCH_IN_SECS  11644473600.0
 inline double IpCoinGetTimeOfDay()


### PR DESCRIPTION
Fixes for several issues reported by Nick Sahinidis and Yi Zhang when extensively testing Ipopt under BARON.