### PR TITLE
set a delta if line search called with fallback activated

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,7 +20,7 @@ More detailed information about incremental changes can be found in the
   in case ConsiderNewSystem failed [#834].
 - Undefine `max` if defined after include of windows.h in IpUtils.cpp [#834].
 - Added missing initialization of Filter Acceptor in case restoration phase is called
-  when the fallback mechanism of BacktrackingLinearSearch has been activated [#834].
+  when the fallback mechanism of BacktrackingLinearSearch has been activated [#834,#837].
   If this happened in the first iteration, it lead to the use of uninitialized values.
 - Added missing return if symbolic factorization with MA57 (ma57ad, ma57as) failed [#834].
 - Fixed application of scaling when computing violations of inequality constraints in

--- a/src/Algorithm/IpBacktrackingLineSearch.cpp
+++ b/src/Algorithm/IpBacktrackingLineSearch.cpp
@@ -321,6 +321,12 @@ void BacktrackingLineSearch::FindAcceptableTrialPoint()
                          "We are in an emergency mode, but no restoration phase or other fall back is available.");
       }
       fallback_activated_ = false; // reset the flag
+
+      // in order to init the line search for the acceptor next, we need a delta to calculate reference_gradBarrTDelta_
+      // since likely we are here because this has failed in PDSearchDirCalculator::ComputeSearchDirection(), we set a new delta now
+      SmartPtr<IteratesVector> delta = IpData().curr()->MakeNewIteratesVector(true);
+      delta->Set(0.0);
+      IpData().set_delta(delta);
    }
    else
    {


### PR DESCRIPTION
To allow for the linear search init in the Filter LS Acceptor to calculate `reference_gradBarrTDelta_`.

Based on a suggestion from Yi Zhang (The OptFirm).