### PR TITLE
ensure Ipopt exception classes have default visibility also in lib that uses Ipopt

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,11 @@ More detailed information about incremental changes can be found in the
 
 ## 3.14
 
+### 3.14.20 (2025-xx-yy)
+
+- Fixed issue where Ipopt exceptions could not been caught from other libraries
+  on macOS with clang when Ipopt or the other library was build with `-fvisibility=hidden`.
+
 ### 3.14.19 (2025-07-30)
 
 - Fixed call to `getenv_s` on Windows, introduced with 3.14.17.

--- a/src/Common/IpException.hpp
+++ b/src/Common/IpException.hpp
@@ -14,6 +14,17 @@
 #include "IpUtils.hpp"
 #include "IpJournalist.hpp"
 
+/* for the exception classes, __attribute__((__visibility__("default"))) needs to be used
+ * also by libraries that link against an Ipopt shared library on macOS/clang,
+ * since otherwise the exceptions cannot be recognized by a catch() in the user code
+ * (https://stackoverflow.com/questions/11913151/catching-derived-exceptions-types-fails-on-clang-macos-x)
+ */
+#if defined(__GNUC__) && __GNUC__ >= 4
+#define IPOPTEXCEPTION_EXPORT __attribute__((__visibility__("default")))
+#else
+#define IPOPTEXCEPTION_EXPORT IPOPTLIB_EXPORT
+#endif
+
 namespace Ipopt
 {
 
@@ -54,7 +65,7 @@ namespace Ipopt
  * Journalist, using the level J_ERROR and the category J_MAIN.
  *
  */
-class IPOPTLIB_EXPORT IpoptException
+class IPOPTEXCEPTION_EXPORT IpoptException
 {
 public:
    /**@name Constructors/Destructors */
@@ -141,7 +152,7 @@ private:
   }
 
 #define DECLARE_STD_EXCEPTION(__except_type) \
-    class IPOPTLIB_EXPORT  __except_type : public Ipopt::IpoptException \
+    class IPOPTEXCEPTION_EXPORT  __except_type : public Ipopt::IpoptException \
     { \
     public: \
       __except_type(const std::string& msg, const std::string& fname, Ipopt::Index line) \


### PR DESCRIPTION
Otherwise, the exceptions could not be recognized when catched in users code on macOS with clang due to different visibility attributes: https://stackoverflow.com/questions/11913151/catching-derived-exceptions-types-fails-on-clang-macos-x.