### PR TITLE
Fix MPI_Init arguments in LpMumpsSolverInterface to fix SIGSEGV with MPICH >= 4.3.1

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -11,6 +11,8 @@ More detailed information about incremental changes can be found in the
 
 - Fixed issue where Ipopt exceptions could not been caught from other libraries
   on macOS with clang when Ipopt or the other library was build with `-fvisibility=hidden`.
+- Call MPI_Init() with NULL instead of dummy arguments to fix SIGSEGV with MPICH >= 4.3.1
+  [#846, by Shengqi Chen].
 
 ### 3.14.19 (2025-07-30)
 

--- a/src/Algorithm/LinearSolvers/IpMumpsSolverInterface.cpp
+++ b/src/Algorithm/LinearSolvers/IpMumpsSolverInterface.cpp
@@ -63,9 +63,7 @@ static void MPIinit(void)
    MPI_Initialized(&mpi_initialized);
    if( !mpi_initialized )
    {
-      int argc = 1;
-      char** argv = NULL;
-      MPI_Init(&argc, &argv);
+      MPI_Init(NULL, NULL);
    }
 }
 


### PR DESCRIPTION
MPICH (>= 4.3.1) will dereference `argv` when `argc` is larger than 0. The previous way of passing arguments will cause a SIGSEGV since `argv` is NULL.

See: https://github.com/pmodels/mpich/commit/e9560dde891ab1414b9aec02a2e8acc4622d5e1b

This was originally reported by Adrian Bunk in Debian BTS [#1111549](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1111549). Related logs:

```
#0  0xf6c2a2b4 in MPIR_Info_setup_env (info_ptr=0xf6ded0ec <MPIR_Info_builtin+20>, argc=1, argv=0x0) at src/mpi/info/infoutil.c:72
#1  0xf6c2b83a in MPII_init_builtin_infos (argc=argc@entry=0xffd02b44, argv=argv@entry=0xffd02b48)
    at src/mpi/init/local_proc_attrs.c:113
#2  0xf6c2a89a in MPII_Init_thread (argc=argc@entry=0xffd02b44, argv=argv@entry=0xffd02b48, user_required=<optimized out>, 
    provided=provided@entry=0xffd02af8, p_session_ptr=<optimized out>, p_session_ptr@entry=0x0) at src/mpi/init/mpir_init.c:216
#3  0xf6c2b130 in MPIR_Init_impl (argc=argc@entry=0xffd02b44, argv=argv@entry=0xffd02b48) at src/mpi/init/mpir_init.c:146
#4  0xf6b295b4 in internal_Init (argc=0xffd02b44, argv=0xffd02b48) at src/binding/c/init/init.c:57
#5  PMPI_Init (argc=0xffd02b44, argv=0xffd02b48) at src/binding/c/init/init.c:108
#6  0xf779a556 in MPIinit () at Algorithm/LinearSolvers/IpMumpsSolverInterface.cpp:68
#7  0xf78eec28 in call_init (l=<optimized out>, argc=1, argv=0xffd02b94, env=0xffd02b9c) at dl-init.c:74
#8  call_init (l=<optimized out>, argc=1, argv=0xffd02b94, env=0xffd02b9c) at dl-init.c:26
#9  0xf78eecd0 in _dl_init (main_map=0xf791ca28, argc=1, argv=0xffd02b94, env=0xffd02b9c) at dl-init.c:121
#10 0xf78fad24 in _dl_start_user () from /lib/ld-linux-armhf.so.3
```

Note: MPI standard allows passing of `NULL`s, and these arguments are not that much useful to the runtime anyway.