### PR TITLE
Fix rare use-after-free in IpSpralSolverInterface

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -13,6 +13,9 @@ More detailed information about incremental changes can be found in the
   on macOS with clang when Ipopt or the other library was build with `-fvisibility=hidden`.
 - Call MPI_Init() with NULL instead of dummy arguments to fix SIGSEGV with MPICH >= 4.3.1
   [#846, by Shengqi Chen].
+- Fixed a use-after-free in Spral interface where attempting to solve a second system with
+  the same structurally singular matrix would end up trying to use an old numeric factorization
+  using data from an already freed symbolic factorization [#848, by Kevin Kofler].
 
 ### 3.14.19 (2025-07-30)
 

--- a/src/Algorithm/LinearSolvers/IpSpralSolverInterface.cpp
+++ b/src/Algorithm/LinearSolvers/IpSpralSolverInterface.cpp
@@ -532,6 +532,10 @@ ESymSolverStatus SpralSolverInterface::MultiSolve(
 
       if( control_.ordering == 2 && control_.scaling == 3 && rescale_ )
       {
+         // Fully invalidate the previous factorization. Otherwise, spral_ssids_analyse_ptr32 is going to
+         // free only the old akeep_, but does not see the old fkeep_ that shares some of its data.
+         spral_ssids_free(&akeep_, &fkeep_);
+
          if( HaveIpData() )
          {
             IpData().TimingStats().LinearSystemSymbolicFactorization().Start();
@@ -675,6 +679,13 @@ ESymSolverStatus SpralSolverInterface::MultiSolve(
    }
    else
    {
+      if( !fkeep_ )
+      {
+         Jnlst().Printf(J_DETAILED, J_LINEAR_ALGEBRA, "In SpralSolverInterface::Factorization: "
+                                                      "Attempting to solve again after failed factorization of singular system\n");
+         return SYMSOLVER_SINGULAR;
+      }
+
       if( HaveIpData() )
       {
          IpData().TimingStats().LinearSystemBackSolve().Start();


### PR DESCRIPTION
src/Algorithm/LinearSolvers/IpSpralSolverInterface.cpp (SpralSolverInterface::MultiSolve): Fix a corner case where attempting to solve a second system with the same structurally singular matrix would end up trying to use an old numeric factorization (fkeep_) using data from an already freed symbolic factorization (akeep_). This was really hard to debug. What was going on was that, if spral_ssids_analyse_ptr32 found the matrix to be structurally singular, Ipopt would return early, without calling spral_ssids_factor_ptr32, so fkeep_ would still point to the old data. Then later, if the same matrix was to be reused (new_matrix=FALSE), Ipopt would try to call spral_ssids_solve on that invalid factorization. The fix is twofold:
1. Before calling spral_ssids_analyse_ptr32, we have to call spral_ssids_free so that both akeep_ and fkeep_ are freed and reset to NULL, because spral_ssids_analyse_ptr32 sees and frees only akeep_. And
2. Before calling spral_ssids_solve, we have to check whether fkeep_ is NULL, in which case we return (again) with SYMSOLVER_SINGULAR.