### PR TITLE
Remove unnecessary <iostream> includes

### DIFF
--- a/src/Algorithm/LinearSolvers/IpMa57TSolverInterface.cpp
+++ b/src/Algorithm/LinearSolvers/IpMa57TSolverInterface.cpp
@@ -9,7 +9,6 @@
 #include "IpMa57TSolverInterface.hpp"
 
 #include <cmath>
-#include <iostream>
 
 #ifdef IPOPT_HAS_HSL
 #include "CoinHslConfig.h"

--- a/src/Algorithm/LinearSolvers/IpMa77SolverInterface.cpp
+++ b/src/Algorithm/LinearSolvers/IpMa77SolverInterface.cpp
@@ -11,7 +11,6 @@
 #include "IpoptConfig.h"
 #include "IpMa77SolverInterface.hpp"
 
-#include <iostream>
 #include <cmath>
 
 #ifdef IPOPT_HAS_HSL

--- a/src/Algorithm/LinearSolvers/IpMa86SolverInterface.cpp
+++ b/src/Algorithm/LinearSolvers/IpMa86SolverInterface.cpp
@@ -11,7 +11,6 @@
 #include "IpoptConfig.h"
 #include "IpMa86SolverInterface.hpp"
 
-#include <iostream>
 #include <cmath>
 
 #ifdef IPOPT_HAS_HSL

--- a/src/Algorithm/LinearSolvers/IpMa97SolverInterface.cpp
+++ b/src/Algorithm/LinearSolvers/IpMa97SolverInterface.cpp
@@ -11,7 +11,6 @@
 #include "IpoptConfig.h"
 #include "IpMa97SolverInterface.hpp"
 
-#include <iostream>
 #include <cstdio>
 #include <cmath>
 #include <cassert>

--- a/src/Common/IpOptionsList.hpp
+++ b/src/Common/IpOptionsList.hpp
@@ -12,7 +12,7 @@
 #include "IpException.hpp"
 #include "IpRegOptions.hpp"
 
-#include <iostream>
+#include <istream>
 #include <map>
 
 namespace Ipopt

--- a/src/Interfaces/IpIpoptApplication.hpp
+++ b/src/Interfaces/IpIpoptApplication.hpp
@@ -7,7 +7,7 @@
 #ifndef __IPIPOPTAPPLICATION_HPP__
 #define __IPIPOPTAPPLICATION_HPP__
 
-#include <iostream>
+#include <istream>
 
 #include "IpJournalist.hpp"
 #include "IpTNLP.hpp"


### PR DESCRIPTION
Including `<iostream>` means introducing the static (global) constructors and destructors for `std::cin`, `std::cerr`, and `std::cout`. That extra init and fini code is undesirable when those streams are not actually used.  See https://en.cppreference.com/w/cpp/io/ios_base/Init.