### PR TITLE
Fix data-race global variables with atomics

### DIFF
--- a/src/Algorithm/IpIpoptAlg.cpp
+++ b/src/Algorithm/IpIpoptAlg.cpp
@@ -4,6 +4,8 @@
 //
 // Authors:  Carl Laird, Andreas Waechter     IBM    2004-08-13
 
+#include <atomic>
+
 #include "IpoptConfig.h"
 #include "IpIpoptAlg.hpp"
 #include "IpJournalist.hpp"
@@ -116,7 +118,7 @@ void IpoptAlgorithm::RegisterOptions(
       "The overall algorithm time is unaffected by this option.");
 }
 
-static bool copyright_message_printed = false;
+static std::atomic_bool copyright_message_printed{false};
 
 bool IpoptAlgorithm::InitializeImpl(
    const OptionsList& options,

--- a/src/Common/IpUtils.cpp
+++ b/src/Common/IpUtils.cpp
@@ -7,6 +7,7 @@
 #include "IpoptConfig.h"
 #include "IpUtils.hpp"
 
+#include <atomic>
 #include <cstdlib>
 #include <cmath>
 #include <cfloat>
@@ -142,7 +143,7 @@ void IpResetRandom01()
 #endif
 }
 
-static double Wallclock_firstCall_ = -1.;
+static std::atomic<double> Wallclock_firstCall_{-1.0};
 
 // The following function were taken from CoinTime.hpp in COIN/Coin
 Number CpuTime()
@@ -185,10 +186,8 @@ Number SysTime()
 Number WallclockTime()
 {
    double callTime = IpCoinGetTimeOfDay();
-   if( Wallclock_firstCall_ == -1. )
-   {
-      Wallclock_firstCall_ = callTime;
-   }
+   double first_call_sentinel = -1.0;
+   Wallclock_firstCall_.compare_exchange_strong(first_call_sentinel, callTime, std::memory_order_seq_cst, std::memory_order_seq_cst);
    return callTime - Wallclock_firstCall_;
 }
 


### PR DESCRIPTION
Without this change, bug detectors like TSan ("thread sanitizer") will flag the global variable access as a data race.