### PR TITLE
remove unnecessary include of iostream; avoid using namespace std

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -18,6 +18,7 @@ More detailed information about incremental changes can be found in the
   using data from an already freed symbolic factorization [#848, by Kevin Kofler].
 - Fixed that the limit on filter resets was not effective [#860, #862, by Lander Vanroye and
   Julien Schueller]. To restore previous behavior, set option max_filter_resets to a high value.
+- Removed unnecessary include of iostream header [#856 by Jeremy Nimmer, #863].
 
 ### 3.14.19 (2025-07-30)
 

--- a/examples/ScalableProblems/solve_problem.cpp
+++ b/examples/ScalableProblems/solve_problem.cpp
@@ -20,7 +20,6 @@
 //**********************************************************************
 
 using namespace Ipopt;
-using namespace std;
 
 // This could probably be done more elegant and automatically, but I
 // can't get it to work right now.  For now, list explicitly the
@@ -147,9 +146,9 @@ int main(
       bool done = false;
       while( !done )
       {
-         string inputword;
-         cout << "Enter problem name (or \"list\" for all available names):\n";
-         cin >> inputword;
+         std::string inputword;
+         std::cout << "Enter problem name (or \"list\" for all available names):\n";
+         std::cin >> inputword;
          if( inputword == "list" )
          {
             print_problems();
@@ -167,8 +166,8 @@ int main(
             }
          }
       }
-      cout << "Enter problem size:\n";
-      cin >> N;
+      std::cout << "Enter problem size:\n";
+      std::cin >> N;
    }
 
    if( N <= 0 )

--- a/src/Algorithm/LinearSolvers/IpMa57TSolverInterface.cpp
+++ b/src/Algorithm/LinearSolvers/IpMa57TSolverInterface.cpp
@@ -9,7 +9,6 @@
 #include "IpMa57TSolverInterface.hpp"
 
 #include <cmath>
-#include <iostream>
 
 #ifdef IPOPT_HAS_HSL
 #include "CoinHslConfig.h"

--- a/src/Algorithm/LinearSolvers/IpMa77SolverInterface.cpp
+++ b/src/Algorithm/LinearSolvers/IpMa77SolverInterface.cpp
@@ -11,14 +11,11 @@
 #include "IpoptConfig.h"
 #include "IpMa77SolverInterface.hpp"
 
-#include <iostream>
 #include <cmath>
 
 #ifdef IPOPT_HAS_HSL
 #include "CoinHslConfig.h"
 #endif
-
-using namespace std;
 
 namespace Ipopt
 {

--- a/src/Algorithm/LinearSolvers/IpMa86SolverInterface.cpp
+++ b/src/Algorithm/LinearSolvers/IpMa86SolverInterface.cpp
@@ -11,14 +11,11 @@
 #include "IpoptConfig.h"
 #include "IpMa86SolverInterface.hpp"
 
-#include <iostream>
 #include <cmath>
 
 #ifdef IPOPT_HAS_HSL
 #include "CoinHslConfig.h"
 #endif
-
-using namespace std;
 
 namespace Ipopt
 {
@@ -307,7 +304,6 @@ ESymSolverStatus Ma86SolverInterface::InitializeStructure(
       if( info.num_flops > info2.num_flops )
       {
          // Use AMD
-         //cout << "Choose AMD\n";
          order_ = order_amd;
          keep_ = keep_amd;
          delete[] order_metis;
@@ -316,7 +312,6 @@ ESymSolverStatus Ma86SolverInterface::InitializeStructure(
       else
       {
          // Use MeTiS
-         //cout << "Choose MeTiS\n";
          order_ = order_metis;
          keep_ = keep_metis;
          delete[] order_amd;

--- a/src/Algorithm/LinearSolvers/IpMa97SolverInterface.cpp
+++ b/src/Algorithm/LinearSolvers/IpMa97SolverInterface.cpp
@@ -11,7 +11,6 @@
 #include "IpoptConfig.h"
 #include "IpMa97SolverInterface.hpp"
 
-#include <iostream>
 #include <cstdio>
 #include <cmath>
 #include <cassert>
@@ -43,8 +42,6 @@ extern "C"
    );
 }
 #endif
-
-using namespace std;
 
 namespace Ipopt
 {
@@ -370,7 +367,7 @@ bool Ma97SolverInterface::InitializeImpl(
    if( scaling_method == "dynamic" )
    {
       scaling_type_ = 0;
-      string switch_val[3], scale_val[3];
+      std::string switch_val[3], scale_val[3];
       options.GetStringValue("ma97_switch1", switch_val[0], prefix);
       options.GetStringValue("ma97_scaling1", scale_val[0], prefix);
       options.GetStringValue("ma97_switch2", switch_val[1], prefix);

--- a/src/Algorithm/LinearSolvers/IpSpralSolverInterface.cpp
+++ b/src/Algorithm/LinearSolvers/IpSpralSolverInterface.cpp
@@ -16,8 +16,6 @@
 #include <cmath>
 #include <cinttypes>
 
-using namespace std;
-
 namespace Ipopt
 {
 

--- a/src/Common/IpOptionsList.hpp
+++ b/src/Common/IpOptionsList.hpp
@@ -12,7 +12,7 @@
 #include "IpException.hpp"
 #include "IpRegOptions.hpp"
 
-#include <iostream>
+#include <istream>
 #include <map>
 
 namespace Ipopt

--- a/src/Common/IpRegOptions.cpp
+++ b/src/Common/IpRegOptions.cpp
@@ -776,15 +776,13 @@ bool RegisteredOption::string_equal_insensitive(
    const std::string& s2
 ) const
 {
-   using namespace std;
-
    if( s1.size() != s2.size() )
    {
       return false;
    }
 
-   string::const_iterator i1 = s1.begin();
-   string::const_iterator i2 = s2.begin();
+   std::string::const_iterator i1 = s1.begin();
+   std::string::const_iterator i2 = s2.begin();
 
    while( i1 != s1.end() )
    {

--- a/src/Interfaces/IpIpoptApplication.hpp
+++ b/src/Interfaces/IpIpoptApplication.hpp
@@ -7,7 +7,7 @@
 #ifndef __IPIPOPTAPPLICATION_HPP__
 #define __IPIPOPTAPPLICATION_HPP__
 
-#include <iostream>
+#include <istream>
 
 #include "IpJournalist.hpp"
 #include "IpTNLP.hpp"

--- a/src/Interfaces/IpStdJInterface.cpp
+++ b/src/Interfaces/IpStdJInterface.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <cassert>
+#include <cstdio>
 #include <jni.h>
 #include "IpTNLP.hpp"
 #include "IpIpoptApplication.hpp"
@@ -293,7 +294,7 @@ Jipopt::Jipopt(
        || get_scaling_parameters_ == 0 || get_number_of_nonlinear_variables_ == 0
        || get_list_of_nonlinear_variables_ == 0 )
    {
-      std::cerr << "Expected callback methods missing on JIpopt.java" << std::endl;
+      printf("\n\n*** Expected callback methods missing on JIpopt.java!\n");
    }
 
    assert(get_bounds_info_    != 0);

--- a/src/Interfaces/IpStdJInterface.cpp
+++ b/src/Interfaces/IpStdJInterface.cpp
@@ -11,7 +11,6 @@
 #include "IpIpoptApplication.hpp"
 #include "org_coinor_Ipopt.h"
 
-using namespace std;
 using namespace Ipopt;
 
 #ifdef IPOPT_SINGLE
@@ -1079,7 +1078,7 @@ extern "C"
       Jipopt* problem = GetRawPtr(*(SmartPtr<Jipopt>*) pipopt);
 
       const char* pparameterName = env->GetStringUTFChars(jparname, 0);
-      string parameterName = pparameterName;
+      std::string parameterName = pparameterName;
 
       // Try to apply the integer option
       jboolean ret = problem->application->Options()->SetIntegerValue(parameterName, jparvalue);
@@ -1100,7 +1099,7 @@ extern "C"
       Jipopt* problem = GetRawPtr(*(SmartPtr<Jipopt>*) pipopt);
 
       const char* pparameterName = env->GetStringUTFChars(jparname, 0);
-      string parameterName = pparameterName;
+      std::string parameterName = pparameterName;
 
       // Try to set the real option
       jboolean ret = problem->application->Options()->SetNumericValue(parameterName, jparvalue);
@@ -1121,9 +1120,9 @@ extern "C"
       Jipopt* problem = GetRawPtr(*(SmartPtr<Jipopt>*) pipopt);
 
       const char* pparameterName = env->GetStringUTFChars(jparname, NULL);
-      string parameterName = pparameterName;
+      std::string parameterName = pparameterName;
       const char* pparameterValue = env->GetStringUTFChars(jparvalue, NULL);
-      string parameterValue = pparameterValue;
+      std::string parameterValue = pparameterValue;
 
       // parameterValue has been changed to LowerCase in Java!
       if( parameterName == "hessian_approximation" && parameterValue == "limited-memory" )


### PR DESCRIPTION
As suggested in #856:
Remove include of `<iostream>` where it is not used.
Replace by `<istream>`, where an `std::istream` is used.

Remove `using namespace std;`